### PR TITLE
[공통] 올해를 기준으로 기수를 계산하는 로직 추가

### DIFF
--- a/src/main/java/com/picksa/picksaserver/applicant/service/ApplicantService.java
+++ b/src/main/java/com/picksa/picksaserver/applicant/service/ApplicantService.java
@@ -4,15 +4,15 @@ import com.picksa.picksaserver.applicant.OrderCondition;
 import com.picksa.picksaserver.applicant.dto.response.ApplicantAllResponse;
 import com.picksa.picksaserver.applicant.dto.response.ApplicantResponse;
 import com.picksa.picksaserver.applicant.repository.ApplicantQueryRepository;
-import com.picksa.picksaserver.global.domain.Generation;
 import com.picksa.picksaserver.global.domain.Part;
 import com.picksa.picksaserver.manager.repository.ManagerRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.Year;
 import java.util.List;
+
+import static com.picksa.picksaserver.global.domain.Generation.getGenerationOfThisYear;
 
 @Service
 @RequiredArgsConstructor
@@ -23,7 +23,7 @@ public class ApplicantService {
 
     @Transactional(readOnly = true)
     public ApplicantAllResponse getAllApplicants(OrderCondition orderCondition) {
-        int generation = getGeneration();
+        int generation = getGenerationOfThisYear();
         int managerCount = getManagerCount(generation);
         List<ApplicantResponse> applicants = applicantQueryRepository.findAllApplicants(orderCondition, generation);
         return ApplicantAllResponse.of(
@@ -35,7 +35,7 @@ public class ApplicantService {
 
     @Transactional(readOnly = true)
     public ApplicantAllResponse getApplicantsByPart(Part part, OrderCondition orderCondition) {
-        int generation = getGeneration();
+        int generation = getGenerationOfThisYear();
         int managerCount = getManagerCount(generation);
         List<ApplicantResponse> applicants = applicantQueryRepository.findApplicantsByPart(part, orderCondition, generation);
         return ApplicantAllResponse.of(
@@ -43,11 +43,6 @@ public class ApplicantService {
                 managerCount,
                 applicants
         );
-    }
-
-    private int getGeneration() {
-        Year year = Year.now();
-        return Generation.from(year).getNumber();
     }
 
     private int getManagerCount(int generation) {

--- a/src/main/java/com/picksa/picksaserver/global/domain/Generation.java
+++ b/src/main/java/com/picksa/picksaserver/global/domain/Generation.java
@@ -26,4 +26,9 @@ public enum Generation {
                 .orElseThrow(() -> new IllegalArgumentException(String.format("%d년도 기수에 해당하는 값이 없습니다.", year.getValue())));
     }
 
+    public static int getGenerationOfThisYear() {
+        Year year = Year.now();
+        return Generation.from(year).getNumber();
+    }
+
 }


### PR DESCRIPTION
기존 applicant 도메인에서만 사용할 수 있던 것을 모든 도메인이 사용할 수 있도록 개선

## 📃 Describe
<!-- 무엇을 위한 PR인지 간략하게 적어주세요-->
- 서버에서 올해를 기준으로 기수를 계산해야 합니다.
- 기존 applicant에만 있던 로직을 공용으로 사용할 수 있도록 개선했습니다.

### 🦁 Changes
<!-- 변경 사항을 적어주세요 -->
- [x] Generation 클래스에 올해를 기준으로 기수를 계산하는 `getGenerationOfThisYear` static 메서드 추가 

### 🧩 Related Issue
<!-- 이 PR이 승인되면 닫을 Issue 번호를 작성해주세요. -->
close # 19

