### PR TITLE
[평가] 운영진 pass 선택 시 지원자 score 업데이트

### DIFF
--- a/src/main/java/com/picksa/picksaserver/applicant/ApplicantEntity.java
+++ b/src/main/java/com/picksa/picksaserver/applicant/ApplicantEntity.java
@@ -94,4 +94,12 @@ public class ApplicantEntity {
 //        this.interviewAvailableTimes = interviewAvailableTimes;
     }
 
+    public void upScore() {
+        this.score++;
+    }
+
+    public void downScore() {
+        this.score--;
+    }
+
 }

--- a/src/main/java/com/picksa/picksaserver/evaluation/EvaluationJpaRepository.java
+++ b/src/main/java/com/picksa/picksaserver/evaluation/EvaluationJpaRepository.java
@@ -1,5 +1,7 @@
 package com.picksa.picksaserver.evaluation;
 
+import com.picksa.picksaserver.applicant.ApplicantEntity;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface EvaluationJpaRepository extends JpaRepository<EvaluationEntity, Long> {
@@ -10,5 +12,7 @@ public interface EvaluationJpaRepository extends JpaRepository<EvaluationEntity,
     }
 
     boolean existsByApplicantIdAndWriterId(Long applicantId, Long memberId);
+
+    List<EvaluationEntity> findAllByApplicant(ApplicantEntity applicant);
 
 }

--- a/src/main/java/com/picksa/picksaserver/evaluation/controller/EvaluationController.java
+++ b/src/main/java/com/picksa/picksaserver/evaluation/controller/EvaluationController.java
@@ -32,9 +32,7 @@ public class EvaluationController {
     }
 
     @GetMapping("/{evaluationId}")
-    public ResponseEntity<EvaluationResponse> get(
-            @PathVariable(name = "evaluationId") Long evaluationId
-    ) {
+    public ResponseEntity<EvaluationResponse> get(@PathVariable(name = "evaluationId") Long evaluationId) {
         return ResponseEntity.ok(service.getEvaluation(evaluationId));
     }
 
@@ -49,8 +47,7 @@ public class EvaluationController {
     }
 
     @GetMapping("/applicant/{applicantId}")
-    public ResponseEntity<?> getByApplicant(
-        @PathVariable(name = "applicantId") Long applicantId) {
+    public ResponseEntity<?> getByApplicant(@PathVariable(name = "applicantId") Long applicantId) {
         return ResponseEntity.ok(service.getEvaluationByApplicant(applicantId));
     }
 

--- a/src/main/java/com/picksa/picksaserver/evaluation/controller/EvaluationController.java
+++ b/src/main/java/com/picksa/picksaserver/evaluation/controller/EvaluationController.java
@@ -48,4 +48,10 @@ public class EvaluationController {
         return ResponseEntity.ok(response);
     }
 
+    @GetMapping("/applicant/{applicantId}")
+    public ResponseEntity<?> getByApplicant(
+        @PathVariable(name = "applicantId") Long applicantId) {
+        return ResponseEntity.ok(service.getEvaluationByApplicant(applicantId));
+    }
+
 }

--- a/src/main/java/com/picksa/picksaserver/evaluation/dto/response/EvaluationResponse.java
+++ b/src/main/java/com/picksa/picksaserver/evaluation/dto/response/EvaluationResponse.java
@@ -5,6 +5,7 @@ import com.picksa.picksaserver.evaluation.EvaluationEntity;
 public record EvaluationResponse(
         Long evaluationId,
         Long managerId,
+        Long applicantId,
         String name,
         Boolean pass,
         String comment
@@ -13,6 +14,7 @@ public record EvaluationResponse(
         return new EvaluationResponse(
             evaluation.getId(),
             evaluation.getWriter().getId(),
+            evaluation.getApplicant().getId(),
             evaluation.getWriter().getName(),
             evaluation.getPass(),
             evaluation.getComment()

--- a/src/main/java/com/picksa/picksaserver/evaluation/dto/response/EvaluationResponse.java
+++ b/src/main/java/com/picksa/picksaserver/evaluation/dto/response/EvaluationResponse.java
@@ -5,13 +5,15 @@ import com.picksa.picksaserver.evaluation.EvaluationEntity;
 public record EvaluationResponse(
         Long evaluationId,
         Long managerId,
+        String name,
         Boolean pass,
         String comment
 ) {
     public static EvaluationResponse of(EvaluationEntity evaluation) {
         return new EvaluationResponse(
-            evaluation.getWriter().getId(),
             evaluation.getId(),
+            evaluation.getWriter().getId(),
+            evaluation.getWriter().getName(),
             evaluation.getPass(),
             evaluation.getComment()
         );

--- a/src/main/java/com/picksa/picksaserver/evaluation/dto/response/EvaluationResponse.java
+++ b/src/main/java/com/picksa/picksaserver/evaluation/dto/response/EvaluationResponse.java
@@ -4,14 +4,16 @@ import com.picksa.picksaserver.evaluation.EvaluationEntity;
 
 public record EvaluationResponse(
         Long evaluationId,
+        Long managerId,
         Boolean pass,
         String comment
 ) {
-    public static EvaluationResponse createEvaluationResponse(EvaluationEntity evaluation) {
+    public static EvaluationResponse of(EvaluationEntity evaluation) {
         return new EvaluationResponse(
-                evaluation.getId(),
-                evaluation.getPass(),
-                evaluation.getComment()
+            evaluation.getWriter().getId(),
+            evaluation.getId(),
+            evaluation.getPass(),
+            evaluation.getComment()
         );
     }
 

--- a/src/main/java/com/picksa/picksaserver/evaluation/service/EvaluationService.java
+++ b/src/main/java/com/picksa/picksaserver/evaluation/service/EvaluationService.java
@@ -9,6 +9,7 @@ import com.picksa.picksaserver.evaluation.dto.response.EvaluationResponse;
 import com.picksa.picksaserver.manager.ManagerEntity;
 import com.picksa.picksaserver.manager.ManagerJpaRepository;
 import java.util.List;
+import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -20,6 +21,7 @@ public class EvaluationService {
     private final EvaluationJpaRepository evaluationRepository;
     private final ApplicantJpaRepository applicantRepository;
     private final ManagerJpaRepository managerRepository;
+
 
     @Transactional
     public EvaluationResponse createEvaluation(Long applicantId, Long managerId, EvaluationRequest request) {
@@ -47,6 +49,10 @@ public class EvaluationService {
     @Transactional
     public EvaluationResponse updateEvaluation(Long evaluationId, Long managerId, EvaluationRequest request) {
         EvaluationEntity evaluation = evaluationRepository.findByIdOrThrow(evaluationId);
+
+        if (!Objects.equals(evaluation.getWriter().getId(), managerId)) {
+            throw new IllegalArgumentException("본인의 평가만 수정이 가능합니다.");
+        }
 
         if (request.comment() != null) {
             evaluation.updateComment(request.comment());

--- a/src/main/java/com/picksa/picksaserver/evaluation/service/EvaluationService.java
+++ b/src/main/java/com/picksa/picksaserver/evaluation/service/EvaluationService.java
@@ -8,6 +8,7 @@ import com.picksa.picksaserver.evaluation.dto.request.EvaluationRequest;
 import com.picksa.picksaserver.evaluation.dto.response.EvaluationResponse;
 import com.picksa.picksaserver.manager.ManagerEntity;
 import com.picksa.picksaserver.manager.ManagerJpaRepository;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -35,12 +36,12 @@ public class EvaluationService {
 
         EvaluationEntity saved = evaluationRepository.save(evaluation);
 
-        return EvaluationResponse.createEvaluationResponse(saved);
+        return EvaluationResponse.of(saved);
     }
 
     public EvaluationResponse getEvaluation(Long evaluationId) {
         EvaluationEntity evaluation = evaluationRepository.findByIdOrThrow(evaluationId);
-        return EvaluationResponse.createEvaluationResponse(evaluation);
+        return EvaluationResponse.of(evaluation);
     }
 
     @Transactional
@@ -55,7 +56,13 @@ public class EvaluationService {
             evaluation.updatePass(request.pass());
         }
 
-        return EvaluationResponse.createEvaluationResponse(evaluation);
+        return EvaluationResponse.of(evaluation);
+    }
+
+    public List<EvaluationResponse> getEvaluationByApplicant(Long applicantId) {
+        ApplicantEntity applicant = applicantRepository.findByIdOrThrow(applicantId);
+        return evaluationRepository.findAllByApplicant(applicant).stream()
+            .map(EvaluationResponse::of).toList();
     }
 
 }

--- a/src/main/java/com/picksa/picksaserver/evaluation/service/EvaluationService.java
+++ b/src/main/java/com/picksa/picksaserver/evaluation/service/EvaluationService.java
@@ -64,18 +64,17 @@ public class EvaluationService {
     public EvaluationResponse updateEvaluation(Long evaluationId, Long managerId, EvaluationRequest request) {
         EvaluationEntity evaluation = evaluationRepository.findByIdOrThrow(evaluationId);
 
-        manageScore(evaluation, request);
-
         if (!Objects.equals(evaluation.getWriter().getId(), managerId)) {
             throw new IllegalArgumentException("본인의 평가만 수정이 가능합니다.");
         }
+
+        manageScore(evaluation, request);
 
         if (request.comment() != null) {
             evaluation.updateComment(request.comment());
         }
 
         if (request.pass() != null) {
-
             evaluation.updatePass(request.pass());
         }
 


### PR DESCRIPTION
## 📃 Describe
<!-- 무엇을 위한 PR인지 간략하게 적어주세요-->
- post 요청으로 처음 평가를 작성할 때, 
- patch로 pass 결과를 수정할 때 
- applicant의 score를 업데이트 하도록 수정하였습니다. 
- 추가적으로 applicantId에 따라 다른 운영진의 평가를 확인할 수 있는 api도 구현하였습니다.
- [notion ticket](<!--관련된 노션 페이지가 없다면 지워주세요 -->)

### 🦁 Changes
<!-- 변경 사항을 적어주세요 -->
- [x] `ApplicantEntity`에 `updateScore` 메소드 추가
- [x] `EvaluationService`의 post, patch 평가 메소드에서 `updateScore` 호출

### 💻 Test
<!-- 테스트 방법에 대해서 적어주세요-->
<!-- 테스트 결과 사진을 올려주세요 -->
기존 평가가 pass 였을 때 score = 4
<img width="300" alt="Screen Shot 2023-12-04 at 9 36 25 PM" src="https://github.com/PickSa/picksa-server/assets/96538554/5bd43ce5-5163-4841-a75e-845ca960a0da">
<br/>
pass를 false로 수정했을 때 score = 3
<img width="300" alt="Screen Shot 2023-12-04 at 9 36 44 PM" src="https://github.com/PickSa/picksa-server/assets/96538554/b2d2cdec-a226-4cf3-a16b-631bd0453d82">


### 🧩 Related Issue
<!-- 이 PR이 승인되면 닫을 Issue 번호를 작성해주세요. -->
close #24 
close #23 

