### PR TITLE
[인가] 인가를 위한 filter 구현

### DIFF
--- a/src/main/java/com/picksa/picksaserver/global/auth/JwtAuthenticationFilter.java
+++ b/src/main/java/com/picksa/picksaserver/global/auth/JwtAuthenticationFilter.java
@@ -1,0 +1,45 @@
+package com.picksa.picksaserver.global.auth;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtManager jwtManager;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) {
+        try {
+            final String token = getTokenFromJwt(request);
+            if (jwtManager.validateToken(token) == JwtValidationType.VALID_JWT) {
+                Long memberId = jwtManager.getUserFromJwt(token);
+                UserAuthentication authentication = new UserAuthentication(memberId.toString(), null, null);       //사용자 객체 생성
+                authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));  // request 정보로 사용자 객체 디테일 설정
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+            }
+        } catch (Exception exception) {
+            throw new RuntimeException("Invalid Token");
+        }
+    }
+
+    private String getTokenFromJwt(HttpServletRequest request) {
+        String bearerToken = request.getHeader("Authorization");
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer ")) {
+            return bearerToken.substring("Bearer ".length());
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/picksa/picksaserver/global/auth/JwtManager.java
+++ b/src/main/java/com/picksa/picksaserver/global/auth/JwtManager.java
@@ -1,0 +1,54 @@
+package com.picksa.picksaserver.global.auth;
+
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
+import org.springframework.beans.factory.annotation.Value;
+
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
+public class JwtManager {
+
+    @Value("${jwt.secret}")
+    private String JWT_SECRET;
+
+    @PostConstruct
+    protected void init() {
+        JWT_SECRET = Base64.getEncoder().encodeToString(JWT_SECRET.getBytes(StandardCharsets.UTF_8));
+    }
+
+    public JwtValidationType validateToken(String token) {
+        try {
+            final Claims claims = getBody(token);
+            return JwtValidationType.VALID_JWT;
+        } catch (MalformedJwtException ex) {
+            return JwtValidationType.INVALID_JWT_TOKEN;
+        } catch (ExpiredJwtException ex) {
+            return JwtValidationType.EXPIRED_JWT_TOKEN;
+        } catch (UnsupportedJwtException ex) {
+            return JwtValidationType.UNSUPPORTED_JWT_TOKEN;
+        } catch (IllegalArgumentException ex) {
+            return JwtValidationType.EMPTY_JWT;
+        }
+    }
+
+    private SecretKey getSigningKey() {
+        String encodedKey= Base64.getEncoder().encodeToString(JWT_SECRET.getBytes());
+        return Keys.hmacShaKeyFor(encodedKey.getBytes());
+    }
+
+    private Claims getBody(final String token) {
+        return Jwts.parserBuilder()
+                .setSigningKey(getSigningKey())
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+    }
+
+    public Long getUserFromJwt(String token) {
+        Claims claims = getBody(token);
+        return Long.valueOf(claims.get("id").toString());
+    }
+}

--- a/src/main/java/com/picksa/picksaserver/global/auth/JwtValidationType.java
+++ b/src/main/java/com/picksa/picksaserver/global/auth/JwtValidationType.java
@@ -1,0 +1,11 @@
+package com.picksa.picksaserver.global.auth;
+
+public enum JwtValidationType {
+    VALID_JWT,
+
+    INVALID_JWT_SIGNATURE,
+    INVALID_JWT_TOKEN,
+    EXPIRED_JWT_TOKEN,
+    UNSUPPORTED_JWT_TOKEN,
+    EMPTY_JWT
+}

--- a/src/main/java/com/picksa/picksaserver/global/auth/UserAuthentication.java
+++ b/src/main/java/com/picksa/picksaserver/global/auth/UserAuthentication.java
@@ -1,0 +1,11 @@
+package com.picksa.picksaserver.global.auth;
+
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.GrantedAuthority;
+
+import java.util.Collection;
+public class UserAuthentication extends UsernamePasswordAuthenticationToken {
+    public UserAuthentication(Object principal, Object credentials, Collection<? extends GrantedAuthority> authorities) {
+        super(principal, credentials, authorities);
+    }
+}


### PR DESCRIPTION
## 📃 Describe
<!-- 무엇을 위한 PR인지 간략하게 적어주세요-->
- 전달 받은 토큰을 처리하는 기능
- global.auth 에 관련 로직들 구현
- JwtAuthenticationFilter
- JwtManager (유효성 검증 및 id, payload 추출)
- UserAuthentication (사용자 인증 정보)
- JwtValidationType (jwt의 검증 결과를 나타내는 enum class)
- [notion ticket](https://www.notion.so/8dfc30d135bb4b7bb823756c2172a2cc)

### 🦁 Changes
<!-- 변경 사항을 적어주세요 -->

### 💻 Test
<!-- 테스트 방법에 대해서 적어주세요-->
<!-- 테스트 결과 사진을 올려주세요 -->


### 🧩 Related Issue
<!-- 이 PR이 승인되면 닫을 Issue 번호를 작성해주세요. -->
close #39 

