### PR TITLE
[설정] 브라우저의 Preflight 요청에 대해 401 에러가 발생하는 문제 해결

### DIFF
--- a/src/main/java/com/picksa/picksaserver/global/config/WebSecurityConfig.java
+++ b/src/main/java/com/picksa/picksaserver/global/config/WebSecurityConfig.java
@@ -12,6 +12,7 @@ import org.springframework.security.config.annotation.web.configurers.HeadersCon
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+import org.springframework.web.cors.CorsUtils;
 
 @Configuration
 @EnableWebSecurity
@@ -25,7 +26,8 @@ public class WebSecurityConfig {
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
                 .formLogin(AbstractHttpConfigurer::disable)
-                .authorizeHttpRequests(auth -> auth
+                .authorizeHttpRequests(request -> request
+                        .requestMatchers(CorsUtils::isPreFlightRequest).permitAll()
                         .requestMatchers(new AntPathRequestMatcher("/api/v1/auth/**")).permitAll()
                         .requestMatchers(new AntPathRequestMatcher("/api/v1/tags/**")).permitAll()
                         .anyRequest()


### PR DESCRIPTION
## 📃 Describe
<!-- 무엇을 위한 PR인지 간략하게 적어주세요-->
- CORS 판별을 하는 Preflight 요청이 Spring Security에 의해 막혀 API 요청에 대하여 CORS 에러가 발생합니다. 

### 🦁 Changes
<!-- 변경 사항을 적어주세요 -->
- [x] Spring Security Preflight 요청에 대해 모두 허용하도록 변경 

### 💻 Test
<!-- 테스트 방법에 대해서 적어주세요-->
- Postman으로 Preflight 요청을 만들어 보내고 `200 OK`가 반환되는 것을 확인했습니다.

### 🧩 Related Issue
<!-- 이 PR이 승인되면 닫을 Issue 번호를 작성해주세요. -->
close #50 

