### PR TITLE
[User] 로그인한 사용자 정보 조회시 role 함께 반환하도록 변경

### DIFF
--- a/src/main/java/com/picksa/picksaserver/user/Position.java
+++ b/src/main/java/com/picksa/picksaserver/user/Position.java
@@ -1,5 +1,8 @@
 package com.picksa.picksaserver.user;
 
+import lombok.Getter;
+
+@Getter
 public enum Position {
 
     PRESIDENT("회장단"),

--- a/src/main/java/com/picksa/picksaserver/user/dto/response/UserResponse.java
+++ b/src/main/java/com/picksa/picksaserver/user/dto/response/UserResponse.java
@@ -3,11 +3,13 @@ package com.picksa.picksaserver.user.dto.response;
 import com.picksa.picksaserver.user.UserEntity;
 
 public record UserResponse(
-        String name
+        String name,
+        String role
 ) {
 
     public static UserResponse from(UserEntity user) {
-        return new UserResponse(user.getName());
+        String role = user.getPosition().getPositionName();
+        return new UserResponse(user.getName(), role);
     }
 
 }


### PR DESCRIPTION
## 📃 Describe
<!-- 무엇을 위한 PR인지 간략하게 적어주세요-->
- 클라이언트에서 사용자별 특정 페이지 접근을 제한하는 데 이용할 수 있게 로그인한 사용자 정보 조회시 role 함께 반환하도록 변경했습니다.
- [notion ticket](https://www.notion.so/api-v1-user-f4645fb93bd749058fe847e3d961da5d?pvs=4)

### 🦁 Changes
<!-- 변경 사항을 적어주세요 -->
- [x] 로그인한 사용자 정보 조회시 role 함께 반환

### 💻 Test
<!-- 테스트 방법에 대해서 적어주세요-->
<!-- 테스트 결과 사진을 올려주세요 -->
![image](https://github.com/PickSa/picksa-server/assets/102007066/3f59eac2-7c0f-42df-9493-f9c29459383b)


### 🧩 Related Issue
<!-- 이 PR이 승인되면 닫을 Issue 번호를 작성해주세요. -->
close #53 

