### PR TITLE
[인증] 인증인가 ErrorResponse 개선 후 permitAll API도 제한되는 문제 해결

### DIFF
--- a/src/main/java/com/picksa/picksaserver/auth/exception/AuthErrorCode.java
+++ b/src/main/java/com/picksa/picksaserver/auth/exception/AuthErrorCode.java
@@ -4,8 +4,9 @@ import com.picksa.picksaserver.global.exception.ErrorCode;
 
 public enum AuthErrorCode implements ErrorCode {
 
+    AUTHENTICATION_EMPTY("A001", "인증 정보가 존재하지 않습니다."),
+
     // JWT
-    TOKEN_EMPTY("A001", "토큰이 존재하지 않습니다."),
     TOKEN_EXPIRED("A002", "토큰이 만료되었습니다."),
     TOKEN_INVALID("A003", "토큰이 유효하지 않습니다."),
 

--- a/src/main/java/com/picksa/picksaserver/global/auth/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/picksa/picksaserver/global/auth/CustomAuthenticationEntryPoint.java
@@ -1,7 +1,6 @@
 package com.picksa.picksaserver.global.auth;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.picksa.picksaserver.auth.exception.TokenEmptyException;
 import com.picksa.picksaserver.global.response.AuthErrorResponse;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;

--- a/src/main/java/com/picksa/picksaserver/global/auth/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/picksa/picksaserver/global/auth/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,36 @@
+package com.picksa.picksaserver.global.auth;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.picksa.picksaserver.auth.exception.TokenEmptyException;
+import com.picksa.picksaserver.global.response.AuthErrorResponse;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+import static com.picksa.picksaserver.auth.exception.AuthErrorCode.AUTHENTICATION_EMPTY;
+
+@Component
+@Slf4j
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException, ServletException {
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("UTF-8");
+
+        AuthErrorResponse errorResponse = AuthErrorResponse.from(AUTHENTICATION_EMPTY);
+        String body = objectMapper.writeValueAsString(errorResponse);
+        response.getWriter().write(body);
+    }
+
+}

--- a/src/main/java/com/picksa/picksaserver/global/auth/JwtAuthenticationFilter.java
+++ b/src/main/java/com/picksa/picksaserver/global/auth/JwtAuthenticationFilter.java
@@ -16,6 +16,7 @@ import org.springframework.web.filter.OncePerRequestFilter;
 import java.io.IOException;
 
 import static com.picksa.picksaserver.auth.exception.AuthErrorCode.USER_NOT_REGISTERED;
+import static com.picksa.picksaserver.global.auth.JwtValidationType.EMPTY_JWT;
 import static com.picksa.picksaserver.global.auth.JwtValidationType.VALID_JWT;
 
 
@@ -33,7 +34,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             if (jwtValidationType == VALID_JWT) {
                 UserAuthentication authentication = jwtManager.getAuthenticationFromJwt(token);
                 SecurityContextHolder.getContext().setAuthentication(authentication);
-            } else {
+            } else if (jwtValidationType != EMPTY_JWT) {
                 throw new JwtAuthenticationException(jwtValidationType.getErrorCode());
             }
         } catch (UsernameNotFoundException exception) {

--- a/src/main/java/com/picksa/picksaserver/global/auth/JwtValidationType.java
+++ b/src/main/java/com/picksa/picksaserver/global/auth/JwtValidationType.java
@@ -9,12 +9,11 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public enum JwtValidationType {
     VALID_JWT,
-
+    EMPTY_JWT,
     INVALID_JWT_SIGNATURE(AuthErrorCode.TOKEN_INVALID),
     INVALID_JWT(AuthErrorCode.TOKEN_INVALID),
     EXPIRED_JWT(AuthErrorCode.TOKEN_EXPIRED),
-    UNSUPPORTED_JWT(AuthErrorCode.TOKEN_INVALID),
-    EMPTY_JWT(AuthErrorCode.TOKEN_EMPTY);
+    UNSUPPORTED_JWT(AuthErrorCode.TOKEN_INVALID);
 
     private ErrorCode errorCode;
 

--- a/src/main/java/com/picksa/picksaserver/global/config/WebSecurityConfig.java
+++ b/src/main/java/com/picksa/picksaserver/global/config/WebSecurityConfig.java
@@ -2,6 +2,7 @@ package com.picksa.picksaserver.global.config;
 
 import com.picksa.picksaserver.global.auth.AuthenticationExceptionHandlerFilter;
 import com.picksa.picksaserver.global.auth.CustomAccessDeniedHandler;
+import com.picksa.picksaserver.global.auth.CustomAuthenticationEntryPoint;
 import com.picksa.picksaserver.global.auth.JwtAuthenticationFilter;
 import com.picksa.picksaserver.user.Position;
 import lombok.RequiredArgsConstructor;
@@ -25,6 +26,7 @@ public class WebSecurityConfig {
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
     private final AuthenticationExceptionHandlerFilter authenticationExceptionHandlerFilter;
     private final CustomAccessDeniedHandler customAccessDeniedHandler;
+    private final CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -42,6 +44,7 @@ public class WebSecurityConfig {
                 .addFilterAfter(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
                 .addFilterBefore(authenticationExceptionHandlerFilter, JwtAuthenticationFilter.class)
                 .exceptionHandling(handler -> handler
+                        .authenticationEntryPoint(customAuthenticationEntryPoint)
                         .accessDeniedHandler(customAccessDeniedHandler)
                 )
                 .csrf(AbstractHttpConfigurer::disable)


### PR DESCRIPTION
## 📃 Describe
<!-- 무엇을 위한 PR인지 간략하게 적어주세요-->
- `JwtAuthenticationFilter `이전에 `ExceptionHandlerFilter`를 둠으로써 JWT 예외를 처리했는데, 이로 인해 `permitAll()` API도 예외 처리를 거치면서 `401 Unauthorized`를 반환하는 문제가 있습니다.
- 토큰이 존재하지 않는 경우 해당 `ExceptionHandlerFilter`에서 처리되지 않도록 하고, `permitAll()` API가 아닌 경우 `CustomAuthenticationEntryPoint`에 의해 ErrorResponse가 반환되도록 변경하였습니다.

### 🦁 Changes
<!-- 변경 사항을 적어주세요 -->
- [x] 토큰이 존재하지 않는 경우 해당 `ExceptionHandlerFilter`에서 처리되지 않도록 변경
- [x] `CustomAuthenticationEntryPoint` 추가
- [x] AuthErrorCode 변경

### 💻 Test
<!-- 테스트 방법에 대해서 적어주세요-->
<!-- 테스트 결과 사진을 올려주세요 -->
- 인증이 필요한 API인데 토큰이 없는 경우
![image](https://github.com/PickSa/picksa-server/assets/102007066/844bc329-9417-450d-ba19-e7c8f57e3628)


### 🧩 Related Issue
<!-- 이 PR이 승인되면 닫을 Issue 번호를 작성해주세요. -->
close #58 

