### PR TITLE
[면접] 면접 일정 생성 기능 추가

### DIFF
--- a/src/main/java/com/picksa/picksaserver/applicant/InterviewScheduleEntity.java
+++ b/src/main/java/com/picksa/picksaserver/applicant/InterviewScheduleEntity.java
@@ -1,0 +1,48 @@
+package com.picksa.picksaserver.applicant;
+
+import com.picksa.picksaserver.global.domain.Generation;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+@Table(name = "interview_schedules")
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class InterviewScheduleEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column
+    private int generation;
+
+    @Column
+    private LocalDate date;
+
+    @Column
+    private LocalTime startAt;
+
+    @Column
+    private LocalTime finishAt;
+
+    @Builder
+    public InterviewScheduleEntity(LocalDate date, LocalTime startAt, LocalTime finishAt) {
+        this.generation = Generation.getGenerationOfThisYear();
+        this.date = date;
+        this.startAt = startAt;
+        this.finishAt = finishAt;
+    }
+
+}

--- a/src/main/java/com/picksa/picksaserver/applicant/controller/InterviewController.java
+++ b/src/main/java/com/picksa/picksaserver/applicant/controller/InterviewController.java
@@ -1,0 +1,30 @@
+package com.picksa.picksaserver.applicant.controller;
+
+import com.picksa.picksaserver.applicant.dto.request.InterviewScheduleCreateRequest;
+import com.picksa.picksaserver.applicant.service.InterviewService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.net.URI;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("api/v1/interview")
+public class InterviewController {
+
+    private final InterviewService interviewService;
+
+    @PostMapping("/schedules")
+    public ResponseEntity<Void> createInterviewSchedule(@RequestBody InterviewScheduleCreateRequest request) {
+        Long interviewScheduleId = interviewService.create(request);
+
+        return ResponseEntity.created(
+                URI.create(String.format("/api/v1/interview/schedules/%d", interviewScheduleId))
+        ).build();
+    }
+
+}

--- a/src/main/java/com/picksa/picksaserver/applicant/dto/request/InterviewScheduleCreateRequest.java
+++ b/src/main/java/com/picksa/picksaserver/applicant/dto/request/InterviewScheduleCreateRequest.java
@@ -1,0 +1,22 @@
+package com.picksa.picksaserver.applicant.dto.request;
+
+import com.picksa.picksaserver.applicant.InterviewScheduleEntity;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+public record InterviewScheduleCreateRequest(
+        LocalDate date,
+        LocalTime startAt,
+        LocalTime finishAt
+) {
+
+    public InterviewScheduleEntity toEntity() {
+        return InterviewScheduleEntity.builder()
+                .date(this.date)
+                .startAt(this.startAt)
+                .finishAt(this.finishAt)
+                .build();
+    }
+
+}

--- a/src/main/java/com/picksa/picksaserver/applicant/repository/InterviewScheduleRepository.java
+++ b/src/main/java/com/picksa/picksaserver/applicant/repository/InterviewScheduleRepository.java
@@ -1,0 +1,12 @@
+package com.picksa.picksaserver.applicant.repository;
+
+import com.picksa.picksaserver.applicant.InterviewScheduleEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface InterviewScheduleRepository extends JpaRepository<InterviewScheduleEntity, Long> {
+
+    List<InterviewScheduleEntity> findByGenerationOrderByDate(int generation);
+
+}

--- a/src/main/java/com/picksa/picksaserver/applicant/service/InterviewService.java
+++ b/src/main/java/com/picksa/picksaserver/applicant/service/InterviewService.java
@@ -1,0 +1,23 @@
+package com.picksa.picksaserver.applicant.service;
+
+import com.picksa.picksaserver.applicant.InterviewScheduleEntity;
+import com.picksa.picksaserver.applicant.dto.request.InterviewScheduleCreateRequest;
+import com.picksa.picksaserver.applicant.repository.InterviewScheduleRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class InterviewService {
+
+    private final InterviewScheduleRepository interviewScheduleRepository;
+
+    @Transactional
+    public Long create(InterviewScheduleCreateRequest request) {
+        InterviewScheduleEntity interviewSchedule = request.toEntity();
+        InterviewScheduleEntity saved = interviewScheduleRepository.save(interviewSchedule);
+        return saved.getId();
+    }
+
+}


### PR DESCRIPTION
## 📃 Describe
<!-- 무엇을 위한 PR인지 간략하게 적어주세요-->
- 면접 일정을 생성하는 기능을 구현했습니다.
- [notion ticket](https://www.notion.so/api-v1-interview-schedules-9aa8f89e864d487c8775c42404bb8ca8?pvs=4)

### 🦁 Changes
<!-- 변경 사항을 적어주세요 -->
- [x] 면접 일정을 나타내는 `InterviewScheduleEntity` 추가
- [x] 면접 일정을 생성하는 기능 구현

### 🧩 Related Issue
<!-- 이 PR이 승인되면 닫을 Issue 번호를 작성해주세요. -->
close #61  

