### PR TITLE
[질문] 질문 순서 조정

### DIFF
--- a/src/main/java/com/picksa/picksaserver/question/QuestionEntity.java
+++ b/src/main/java/com/picksa/picksaserver/question/QuestionEntity.java
@@ -1,6 +1,7 @@
 package com.picksa.picksaserver.question;
 
 import com.picksa.picksaserver.question.dto.QuestionDetermine;
+import com.picksa.picksaserver.question.dto.response.QuestionUpdateSequenceResponse;
 import com.picksa.picksaserver.user.UserEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -70,6 +71,11 @@ public class QuestionEntity {
 
     public void deleteQuestion() {
         this.deletedAt = LocalDateTime.now();
+    }
+
+    public QuestionUpdateSequenceResponse updateSequence(int sequence) {
+        this.sequence = sequence;
+        return new QuestionUpdateSequenceResponse(this.id, this.sequence);
     }
 }
 

--- a/src/main/java/com/picksa/picksaserver/question/controller/QuestionController.java
+++ b/src/main/java/com/picksa/picksaserver/question/controller/QuestionController.java
@@ -4,9 +4,11 @@ import com.picksa.picksaserver.global.domain.Part;
 import com.picksa.picksaserver.question.QuestionOrderCondition;
 import com.picksa.picksaserver.question.dto.QuestionDetermine;
 import com.picksa.picksaserver.question.dto.request.QuestionCreateRequest;
+import com.picksa.picksaserver.question.dto.request.QuestionUpdateSequenceRequest;
 import com.picksa.picksaserver.question.dto.response.QuestionCreateResponse;
 import com.picksa.picksaserver.question.dto.response.QuestionDeleteResponse;
 import com.picksa.picksaserver.question.dto.response.QuestionResponse;
+import com.picksa.picksaserver.question.dto.response.QuestionUpdateSequenceResponse;
 import com.picksa.picksaserver.question.service.QuestionService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -78,6 +80,14 @@ public class QuestionController {
     		) {
         QuestionDeleteResponse response = questionService.deleteQuestion(questionId);
     	return ResponseEntity.ok(response);
+    }
+
+    @PatchMapping("/reorder")
+    public ResponseEntity<List<QuestionUpdateSequenceResponse>> updateOrder(
+            @RequestBody List<QuestionUpdateSequenceRequest> requests
+    ) {
+        List<QuestionUpdateSequenceResponse> response = questionService.updateOrder(requests);
+        return ResponseEntity.ok(response);
     }
 
 }

--- a/src/main/java/com/picksa/picksaserver/question/dto/request/QuestionUpdateSequenceRequest.java
+++ b/src/main/java/com/picksa/picksaserver/question/dto/request/QuestionUpdateSequenceRequest.java
@@ -1,0 +1,4 @@
+package com.picksa.picksaserver.question.dto.request;
+
+public record QuestionUpdateSequenceRequest(Long id, int sequence) {
+}

--- a/src/main/java/com/picksa/picksaserver/question/dto/response/QuestionUpdateSequenceResponse.java
+++ b/src/main/java/com/picksa/picksaserver/question/dto/response/QuestionUpdateSequenceResponse.java
@@ -1,0 +1,4 @@
+package com.picksa.picksaserver.question.dto.response;
+
+public record QuestionUpdateSequenceResponse(Long id, int sequence) {
+}


### PR DESCRIPTION
## 📃 Describe
<!-- 무엇을 위한 PR인지 간략하게 적어주세요-->
- 질문 순서 조정 기능을 깜빡하고 있었네요ㅜㅠ 이슈 페이지 보다가 놀라서 후다닥 만들었습니다,, 
- 질문 조정할 리스트를 한번에 받는 걸로 바뀌어서 동시성 문제는 없을 것 같아 다른 api처럼 만들었어요
- [notion ticket](https://www.notion.so/api-v1-questions-reorder-bce5f34ca6874283a41b427675f94447)

### 🦁 Changes
<!-- 변경 사항을 적어주세요 -->
- [X] 질문 순서 기능 추가
- [X] 질문의 확정 여부 결정하는 api 수정: `isDetermined == false`인 경우 sequence를 0으로 초기화하는 로직을 추가했습니다.

### 💻 Test
<!-- 테스트 방법에 대해서 적어주세요-->
DB 상태
![image](https://github.com/PickSa/picksa-server/assets/71963320/a6206593-0213-46d5-ab41-53796f338ac1)

</br>

<!-- 테스트 결과 사진을 올려주세요 -->
* 질문 순서 조정
![image](https://github.com/PickSa/picksa-server/assets/71963320/11b3e2fe-562b-434d-b2b0-fe88c6726eaf)

</br>

* isDetermined가 false인 질문이 있는 경우
![image](https://github.com/PickSa/picksa-server/assets/71963320/cfbd1d5e-8384-4911-871f-0922c2f34f20)


### 🧩 Related Issue
<!-- 이 PR이 승인되면 닫을 Issue 번호를 작성해주세요. -->
close #32 

