### PR TITLE
[지원자] 합격자 인터뷰 가능 시간 조회 기능 구현

### DIFF
--- a/src/main/java/com/picksa/picksaserver/applicant/ApplicantEntity.java
+++ b/src/main/java/com/picksa/picksaserver/applicant/ApplicantEntity.java
@@ -70,13 +70,25 @@ public class ApplicantEntity {
     @Enumerated(EnumType.STRING)
     private Result result;
 
-//    @ElementCollection
-//    @CollectionTable(name = "interview_availables", joinColumns = @JoinColumn(name = "applicant_id"))
-//    private List<InterviewAvailableTime> interviewAvailableTimes;
-// TODO: 2023-11-18 면접 가능 시간 처리
+    @Column(nullable = false, length = 120)
+    private String interviewAvailableTimes;
 
     @Builder
-    public ApplicantEntity(String name, String studentId, String semester, String gender, String phone, String email, String major, String multiMajor, Part part, int generation, String portfolio, int score, boolean isEvaluated, Result result, List<InterviewAvailableTime> interviewAvailableTimes) {
+    public ApplicantEntity(String name,
+                           String studentId,
+                           String semester,
+                           String gender,
+                           String phone,
+                           String email,
+                           String major,
+                           String multiMajor,
+                           Part part,
+                           int generation,
+                           String portfolio,
+                           int score,
+                           boolean isEvaluated,
+                           Result result,
+                           String interviewAvailableTimes) {
         this.name = name;
         this.studentId = studentId;
         this.semester = semester;
@@ -91,7 +103,7 @@ public class ApplicantEntity {
         this.score = score;
         this.isEvaluated = isEvaluated;
         this.result = result;
-//        this.interviewAvailableTimes = interviewAvailableTimes;
+        this.interviewAvailableTimes = interviewAvailableTimes;
     }
 
     public void upScore() {

--- a/src/main/java/com/picksa/picksaserver/applicant/controller/ApplicantController.java
+++ b/src/main/java/com/picksa/picksaserver/applicant/controller/ApplicantController.java
@@ -3,6 +3,7 @@ package com.picksa.picksaserver.applicant.controller;
 import com.picksa.picksaserver.applicant.OrderCondition;
 import com.picksa.picksaserver.applicant.dto.response.ApplicantAllResponse;
 import com.picksa.picksaserver.applicant.dto.response.ApplicantDetailResponse;
+import com.picksa.picksaserver.applicant.dto.response.ApplicantScheduleResponses;
 import com.picksa.picksaserver.applicant.service.ApplicantService;
 import com.picksa.picksaserver.global.domain.Part;
 import lombok.RequiredArgsConstructor;
@@ -42,6 +43,12 @@ public class ApplicantController {
     public ResponseEntity<ApplicantDetailResponse> getApplicantDetail(@PathVariable Long applicantId) {
         ApplicantDetailResponse response = applicantService.getApplicantDetail(applicantId);
 
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/interview/schedule")
+    public ResponseEntity<ApplicantScheduleResponses> getApplicantSchedules() {
+        ApplicantScheduleResponses response = applicantService.getApplicantsSchedules();
         return ResponseEntity.ok(response);
     }
 

--- a/src/main/java/com/picksa/picksaserver/applicant/controller/ApplicantController.java
+++ b/src/main/java/com/picksa/picksaserver/applicant/controller/ApplicantController.java
@@ -46,7 +46,7 @@ public class ApplicantController {
         return ResponseEntity.ok(response);
     }
 
-    @GetMapping("/interview/schedule")
+    @GetMapping("/interview/schedules")
     public ResponseEntity<ApplicantScheduleResponses> getApplicantSchedules() {
         ApplicantScheduleResponses response = applicantService.getApplicantsSchedules();
         return ResponseEntity.ok(response);

--- a/src/main/java/com/picksa/picksaserver/applicant/dto/response/ApplicantScheduleResponse.java
+++ b/src/main/java/com/picksa/picksaserver/applicant/dto/response/ApplicantScheduleResponse.java
@@ -1,0 +1,11 @@
+package com.picksa.picksaserver.applicant.dto.response;
+
+import com.picksa.picksaserver.global.domain.Part;
+
+public record ApplicantScheduleResponse(
+        Long id,
+        String name,
+        Part part,
+        String available
+) {
+}

--- a/src/main/java/com/picksa/picksaserver/applicant/dto/response/ApplicantScheduleResponses.java
+++ b/src/main/java/com/picksa/picksaserver/applicant/dto/response/ApplicantScheduleResponses.java
@@ -1,0 +1,12 @@
+package com.picksa.picksaserver.applicant.dto.response;
+
+import java.util.List;
+
+public record ApplicantScheduleResponses(
+        List<InterviewScheduleResponse> schedules,
+        List<ApplicantScheduleResponse> applicants
+) {
+    public static ApplicantScheduleResponses of(List<InterviewScheduleResponse> schedules, List<ApplicantScheduleResponse> applicants) {
+        return new ApplicantScheduleResponses(schedules, applicants);
+    }
+}

--- a/src/main/java/com/picksa/picksaserver/applicant/dto/response/InterviewScheduleResponse.java
+++ b/src/main/java/com/picksa/picksaserver/applicant/dto/response/InterviewScheduleResponse.java
@@ -1,0 +1,25 @@
+package com.picksa.picksaserver.applicant.dto.response;
+
+import com.picksa.picksaserver.applicant.InterviewScheduleEntity;
+import lombok.Builder;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+@Builder
+public record InterviewScheduleResponse(
+        LocalDate date,
+        LocalTime startAt,
+        LocalTime finishAt
+) {
+
+    public static InterviewScheduleResponse from(InterviewScheduleEntity interviewSchedule) {
+        return InterviewScheduleResponse.builder()
+                .date(interviewSchedule.getDate())
+                .startAt(interviewSchedule.getStartAt())
+                .finishAt(interviewSchedule.getFinishAt())
+                .build();
+    }
+
+}

--- a/src/main/java/com/picksa/picksaserver/applicant/repository/ApplicantQueryRepository.java
+++ b/src/main/java/com/picksa/picksaserver/applicant/repository/ApplicantQueryRepository.java
@@ -2,6 +2,7 @@ package com.picksa.picksaserver.applicant.repository;
 
 import com.picksa.picksaserver.applicant.OrderCondition;
 import com.picksa.picksaserver.applicant.dto.response.ApplicantResponse;
+import com.picksa.picksaserver.applicant.dto.response.ApplicantScheduleResponse;
 import com.picksa.picksaserver.global.domain.Part;
 
 import java.util.List;
@@ -13,4 +14,5 @@ public interface ApplicantQueryRepository {
 
     List<ApplicantResponse> findApplicantsByPart(Part part, OrderCondition orderCondition, int generation);
 
+    List<ApplicantScheduleResponse> findApplicantSchedules(int generation);
 }

--- a/src/main/java/com/picksa/picksaserver/applicant/repository/ApplicantQueryRepositoryImpl.java
+++ b/src/main/java/com/picksa/picksaserver/applicant/repository/ApplicantQueryRepositoryImpl.java
@@ -1,7 +1,9 @@
 package com.picksa.picksaserver.applicant.repository;
 
 import com.picksa.picksaserver.applicant.OrderCondition;
+import com.picksa.picksaserver.applicant.Result;
 import com.picksa.picksaserver.applicant.dto.response.ApplicantResponse;
+import com.picksa.picksaserver.applicant.dto.response.ApplicantScheduleResponse;
 import com.picksa.picksaserver.global.domain.Part;
 import com.querydsl.core.types.NullExpression;
 import com.querydsl.core.types.Order;
@@ -67,6 +69,25 @@ public class ApplicantQueryRepositoryImpl implements ApplicantQueryRepository {
                         applicantEntity.part.eq(part))
                 .orderBy(
                         orderByField(orderCondition),
+                        applicantEntity.name.asc()
+                )
+                .fetch();
+    }
+
+    @Override
+    public List<ApplicantScheduleResponse> findApplicantSchedules(int generation) {
+        return jpaQueryFactory.select(Projections.constructor(
+                        ApplicantScheduleResponse.class,
+                        applicantEntity.id,
+                        applicantEntity.name,
+                        applicantEntity.part,
+                        applicantEntity.interviewAvailableTimes
+                ))
+                .from(applicantEntity)
+                .where(applicantEntity.generation.eq(generation),
+                        applicantEntity.result.eq(Result.PASS))
+                .orderBy(
+                        partOrder.asc(),
                         applicantEntity.name.asc()
                 )
                 .fetch();

--- a/src/main/java/com/picksa/picksaserver/applicant/service/ApplicantService.java
+++ b/src/main/java/com/picksa/picksaserver/applicant/service/ApplicantService.java
@@ -2,12 +2,17 @@ package com.picksa.picksaserver.applicant.service;
 
 import com.picksa.picksaserver.applicant.AnswerEntity;
 import com.picksa.picksaserver.applicant.ApplicantEntity;
+import com.picksa.picksaserver.applicant.InterviewScheduleEntity;
 import com.picksa.picksaserver.applicant.OrderCondition;
 import com.picksa.picksaserver.applicant.dto.response.ApplicantAllResponse;
 import com.picksa.picksaserver.applicant.dto.response.ApplicantDetailResponse;
 import com.picksa.picksaserver.applicant.dto.response.ApplicantResponse;
+import com.picksa.picksaserver.applicant.dto.response.ApplicantScheduleResponse;
+import com.picksa.picksaserver.applicant.dto.response.ApplicantScheduleResponses;
+import com.picksa.picksaserver.applicant.dto.response.InterviewScheduleResponse;
 import com.picksa.picksaserver.applicant.repository.AnswerRepository;
 import com.picksa.picksaserver.applicant.repository.ApplicantRepository;
+import com.picksa.picksaserver.applicant.repository.InterviewScheduleRepository;
 import com.picksa.picksaserver.global.domain.Part;
 import com.picksa.picksaserver.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -26,11 +31,12 @@ public class ApplicantService {
     private final ApplicantRepository applicantRepository;
     private final AnswerRepository answerRepository;
     private final UserRepository userRepository;
+    private final InterviewScheduleRepository interviewScheduleRepository;
 
     @Transactional(readOnly = true)
     public ApplicantAllResponse getAllApplicants(OrderCondition orderCondition) {
         int generation = getGenerationOfThisYear();
-        int userCount = getuserCount(generation);
+        int userCount = getUserCount(generation);
         List<ApplicantResponse> applicants = applicantRepository.findAllApplicants(orderCondition, generation);
         return ApplicantAllResponse.of(
                 generation,
@@ -42,7 +48,7 @@ public class ApplicantService {
     @Transactional(readOnly = true)
     public ApplicantAllResponse getApplicantsByPart(Part part, OrderCondition orderCondition) {
         int generation = getGenerationOfThisYear();
-        int userCount = getuserCount(generation);
+        int userCount = getUserCount(generation);
         List<ApplicantResponse> applicants = applicantRepository.findApplicantsByPart(part, orderCondition, generation);
         return ApplicantAllResponse.of(
                 generation,
@@ -60,7 +66,18 @@ public class ApplicantService {
         return ApplicantDetailResponse.of(applicant, answers);
     }
 
-    private int getuserCount(int generation) {
+    @Transactional(readOnly = true)
+    public ApplicantScheduleResponses getApplicantsSchedules() {
+        int generation = getGenerationOfThisYear();
+        List<InterviewScheduleEntity> interviewSchedules = interviewScheduleRepository.findByGenerationOrderByDate(generation);
+        List<InterviewScheduleResponse> schedules = interviewSchedules.stream().map(InterviewScheduleResponse::from).toList();
+        List<ApplicantScheduleResponse> applicants = applicantRepository.findApplicantSchedules(generation);
+
+        return ApplicantScheduleResponses.of(schedules, applicants);
+
+    }
+
+    private int getUserCount(int generation) {
         return userRepository.countByGeneration(generation);
     }
 

--- a/src/main/java/com/picksa/picksaserver/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/picksa/picksaserver/global/exception/GlobalExceptionHandler.java
@@ -9,13 +9,14 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
 import static org.springframework.http.HttpStatus.FORBIDDEN;
+import static org.springframework.http.HttpStatus.NOT_FOUND;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
     @ExceptionHandler(EntityNotFoundException.class)
     public ResponseEntity<DefaultErrorResponse> handleEntityNotFoundException(EntityNotFoundException exception) {
-        return ResponseEntity.status(BAD_REQUEST)
+        return ResponseEntity.status(NOT_FOUND)
                 .body(DefaultErrorResponse.from(exception.getMessage()));    }
 
     @ExceptionHandler(IllegalArgumentException.class)


### PR DESCRIPTION
## 📃 Describe
<!-- 무엇을 위한 PR인지 간략하게 적어주세요-->
- 합격자의 면접 가능 시간을 조회하는 기능을 구현했습니다.
- [notion ticket](https://www.notion.so/api-v1-applicants-interview-schedule-673dffb9ae684a4e95601b572008176a?pvs=4)

### 🦁 Changes
<!-- 변경 사항을 적어주세요 -->
- [x] `ApplicantEntity`에 합격자의 면접 가능 시간을 나타내는 `interviewAvailableTimes` 필드를 추가했습니다.

### 💻 Test
<!-- 테스트 방법에 대해서 적어주세요-->
<!-- 테스트 결과 사진을 올려주세요 -->
![image](https://github.com/PickSa/picksa-server/assets/102007066/ff48f06f-9364-478f-b662-796e606b389c)


### 🧩 Related Issue
<!-- 이 PR이 승인되면 닫을 Issue 번호를 작성해주세요. -->
close #22  

