### PR TITLE
[지원자] 지원자 전체 조회 기능 정렬 방식 수정

### DIFF
--- a/src/main/java/com/picksa/picksaserver/applicant/controller/ApplicantController.java
+++ b/src/main/java/com/picksa/picksaserver/applicant/controller/ApplicantController.java
@@ -24,8 +24,13 @@ public class ApplicantController {
 
     @GetMapping("/all")
     public ResponseEntity<ApplicantAllResponse> getAllApplicants(@RequestParam(required = false) String order) {
+        if (order == null) {
+            ApplicantAllResponse response = applicantService.getAllApplicants();
+            return ResponseEntity.ok(response);
+        }
+
         OrderCondition orderCondition = getOrderCondition(order);
-        ApplicantAllResponse response = applicantService.getAllApplicants(orderCondition);
+        ApplicantAllResponse response = applicantService.getAllApplicantsByOrderCondition(orderCondition);
 
         return ResponseEntity.ok(response);
     }

--- a/src/main/java/com/picksa/picksaserver/applicant/repository/ApplicantQueryRepository.java
+++ b/src/main/java/com/picksa/picksaserver/applicant/repository/ApplicantQueryRepository.java
@@ -10,7 +10,9 @@ import java.util.List;
 
 public interface ApplicantQueryRepository {
 
-    List<ApplicantResponse> findAllApplicants(OrderCondition orderCondition, int generation);
+    List<ApplicantResponse> findAllApplicants(int generation);
+
+    List<ApplicantResponse> findAllApplicantsByOrderCondition(OrderCondition orderCondition, int generation);
 
     List<ApplicantResponse> findApplicantsByPart(Part part, OrderCondition orderCondition, int generation);
 

--- a/src/main/java/com/picksa/picksaserver/applicant/repository/ApplicantQueryRepositoryImpl.java
+++ b/src/main/java/com/picksa/picksaserver/applicant/repository/ApplicantQueryRepositoryImpl.java
@@ -32,7 +32,7 @@ public class ApplicantQueryRepositoryImpl implements ApplicantQueryRepository {
     );
 
     @Override
-    public List<ApplicantResponse> findAllApplicants(OrderCondition orderCondition, int generation) {
+    public List<ApplicantResponse> findAllApplicants(int generation) {
         return jpaQueryFactory.select(Projections.constructor(
                         ApplicantResponse.class,
                         applicantEntity.id,
@@ -47,7 +47,27 @@ public class ApplicantQueryRepositoryImpl implements ApplicantQueryRepository {
                 .where(applicantEntity.generation.eq(generation))
                 .orderBy(
                         partOrder.asc(),
+                        applicantEntity.name.asc())
+                .fetch();
+    }
+
+    @Override
+    public List<ApplicantResponse> findAllApplicantsByOrderCondition(OrderCondition orderCondition, int generation) {
+        return jpaQueryFactory.select(Projections.constructor(
+                        ApplicantResponse.class,
+                        applicantEntity.id,
+                        applicantEntity.part,
+                        applicantEntity.name,
+                        applicantEntity.studentId,
+                        applicantEntity.phone,
+                        applicantEntity.score,
+                        applicantEntity.isEvaluated,
+                        applicantEntity.result))
+                .from(applicantEntity)
+                .where(applicantEntity.generation.eq(generation))
+                .orderBy(
                         orderByField(orderCondition),
+                        partOrder.asc(),
                         applicantEntity.name.asc())
                 .fetch();
     }

--- a/src/main/java/com/picksa/picksaserver/applicant/service/ApplicantService.java
+++ b/src/main/java/com/picksa/picksaserver/applicant/service/ApplicantService.java
@@ -34,10 +34,22 @@ public class ApplicantService {
     private final InterviewScheduleRepository interviewScheduleRepository;
 
     @Transactional(readOnly = true)
-    public ApplicantAllResponse getAllApplicants(OrderCondition orderCondition) {
+    public ApplicantAllResponse getAllApplicants() {
         int generation = getGenerationOfThisYear();
         int userCount = getUserCount(generation);
-        List<ApplicantResponse> applicants = applicantRepository.findAllApplicants(orderCondition, generation);
+        List<ApplicantResponse> applicants = applicantRepository.findAllApplicants(generation);
+        return ApplicantAllResponse.of(
+                generation,
+                userCount,
+                applicants
+        );
+    }
+
+    @Transactional(readOnly = true)
+    public ApplicantAllResponse getAllApplicantsByOrderCondition(OrderCondition orderCondition) {
+        int generation = getGenerationOfThisYear();
+        int userCount = getUserCount(generation);
+        List<ApplicantResponse> applicants = applicantRepository.findAllApplicantsByOrderCondition(orderCondition, generation);
         return ApplicantAllResponse.of(
                 generation,
                 userCount,


### PR DESCRIPTION
## 📃 Describe
<!-- 무엇을 위한 PR인지 간략하게 적어주세요-->
QA를 진행하면서 지원자 전체 조회 기능에서 정렬 방식에서 수정이 필요한 사항이 발견되었습니다. 
지원자 전체 조회 시 정렬 조건이 존재하면, 해당 정렬 조건이 파트순+이름순보다 우선해야 합니다.
- 현재 방식: 파트별+가나다순 우선순위가 고정 → 기획(미정>합>불)>디자인(미정>합>불)>프론트(미정>합>불)>백(미정>합>불)
- 요구사항: 기획 미정>디자인 미정>프론트 미정>백 미정>기획(합>불)>디자인(합>불)>프론트(합>불)>백(합>불)

### 🦁 Changes
<!-- 변경 사항을 적어주세요 -->
- [x] `ApplicantQueryRepository`의 `findAllApplicants`에서 정렬 조건에 따른 동적 정렬 제거
- [x] `ApplicantQueryRepository`에 정렬 조건에 따라 동적 정렬을 하는 `findAllApplicantsByOrderCondition` 추가
- [x] `ApplicantController`에서 정렬 조건 유무에 따라 서비스 코드 분기 처리

### 🧩 Related Issue
<!-- 이 PR이 승인되면 닫을 Issue 번호를 작성해주세요. -->
close #75 


