### PR TITLE
[지원자] 지원서 원본(OriginalApplication)->Application 형식으로 변환하여 저장하는 기능 구현

### DIFF
--- a/src/main/java/com/picksa/picksaserver/PicksaServerApplication.java
+++ b/src/main/java/com/picksa/picksaserver/PicksaServerApplication.java
@@ -2,10 +2,8 @@ package com.picksa.picksaserver;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
-@EnableJpaAuditing
 public class PicksaServerApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/picksa/picksaserver/applicant/domain/ApplicantEntity.java
+++ b/src/main/java/com/picksa/picksaserver/applicant/domain/ApplicantEntity.java
@@ -83,9 +83,7 @@ public class ApplicantEntity {
                            Part part,
                            int generation,
                            String portfolio,
-                           int score,
                            boolean isEvaluated,
-                           Result result,
                            String interviewAvailableTimes) {
         this.name = name;
         this.studentId = studentId;
@@ -98,9 +96,9 @@ public class ApplicantEntity {
         this.part = part;
         this.generation = generation;
         this.portfolio = portfolio;
-        this.score = score;
+        this.score = 0;
         this.isEvaluated = isEvaluated;
-        this.result = result;
+        this.result = Result.PENDING;
         this.interviewAvailableTimes = interviewAvailableTimes;
     }
 

--- a/src/main/java/com/picksa/picksaserver/application/controller/ApplicationController.java
+++ b/src/main/java/com/picksa/picksaserver/application/controller/ApplicationController.java
@@ -22,4 +22,10 @@ public class ApplicationController {
         return ResponseEntity.ok().build();
     }
 
+    @PostMapping("/applicant")
+    public ResponseEntity<Void> convertApplicationToApplicant() {
+        applicationConvertService.convertApplicationToApplicant();
+        return ResponseEntity.ok().build();
+    }
+
 }

--- a/src/main/java/com/picksa/picksaserver/application/controller/ApplicationController.java
+++ b/src/main/java/com/picksa/picksaserver/application/controller/ApplicationController.java
@@ -1,0 +1,25 @@
+package com.picksa.picksaserver.application.controller;
+
+import com.picksa.picksaserver.application.service.ApplicationConvertService;
+import com.picksa.picksaserver.application.service.OriginalApplicationConvertService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("api/v1/applications")
+public class ApplicationController {
+
+    private final OriginalApplicationConvertService originalApplicationConvertService;
+    private final ApplicationConvertService applicationConvertService;
+
+    @PostMapping("/original")
+    public ResponseEntity<Void> convertOriginalToApplication() {
+        originalApplicationConvertService.convertOriginalToApplication();
+        return ResponseEntity.ok().build();
+    }
+
+}

--- a/src/main/java/com/picksa/picksaserver/application/domain/ApplicationEntity.java
+++ b/src/main/java/com/picksa/picksaserver/application/domain/ApplicationEntity.java
@@ -1,0 +1,68 @@
+package com.picksa.picksaserver.application.domain;
+
+import com.picksa.picksaserver.application.domain.CommonAnswers;
+import com.picksa.picksaserver.application.domain.PartAnswers;
+import com.picksa.picksaserver.application.domain.PersonalData;
+import com.picksa.picksaserver.global.domain.BaseEntity;
+import com.picksa.picksaserver.global.domain.Part;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Table(name = "applications")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ApplicationEntity extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column
+    private boolean agreePrivacyCollection;
+
+    @Enumerated(EnumType.STRING)
+    private Part part;
+
+    @Column
+    private int generation;
+
+    @Embedded
+    private PersonalData personalData;
+
+    @Embedded
+    private CommonAnswers commonAnswers;
+
+    @Embedded
+    private PartAnswers partAnswers;
+
+    @Column
+    private String interviewAvailableTimes;
+
+    @Column
+    private Long originalId;
+
+    @Builder
+    public ApplicationEntity(boolean agreePrivacyCollection, Part part, int generation, PersonalData personalData, CommonAnswers commonAnswers, PartAnswers partAnswers, String interviewAvailableTimes, Long originalId) {
+        this.agreePrivacyCollection = agreePrivacyCollection;
+        this.part = part;
+        this.personalData = personalData;
+        this.commonAnswers = commonAnswers;
+        this.partAnswers = partAnswers;
+        this.interviewAvailableTimes = interviewAvailableTimes;
+        this.generation = generation;
+        this.originalId = originalId;
+    }
+
+}

--- a/src/main/java/com/picksa/picksaserver/application/domain/CommonAnswers.java
+++ b/src/main/java/com/picksa/picksaserver/application/domain/CommonAnswers.java
@@ -1,0 +1,26 @@
+package com.picksa.picksaserver.application.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.Getter;
+
+@Getter
+@Embeddable
+public class CommonAnswers {
+
+    @Column(length = 1000)
+    private String commonAnswer1;
+
+    @Column(length = 1000)
+    private String commonAnswer2;
+
+    @Column(length = 1000)
+    private String commonAnswer3;
+
+    @Column(length = 1000)
+    private String commonAnswer4;
+
+    @Column(length = 1000)
+    private String commonAnswer5;
+
+}

--- a/src/main/java/com/picksa/picksaserver/application/domain/InterviewAvailable.java
+++ b/src/main/java/com/picksa/picksaserver/application/domain/InterviewAvailable.java
@@ -1,0 +1,14 @@
+package com.picksa.picksaserver.application.domain;
+
+import jakarta.persistence.Embeddable;
+import lombok.Getter;
+
+@Getter
+@Embeddable
+public class InterviewAvailable {
+
+    private String day1;
+    private String day2;
+    private String day3;
+
+}

--- a/src/main/java/com/picksa/picksaserver/application/domain/OriginalApplicationEntity.java
+++ b/src/main/java/com/picksa/picksaserver/application/domain/OriginalApplicationEntity.java
@@ -1,0 +1,92 @@
+package com.picksa.picksaserver.application.domain;
+
+import com.picksa.picksaserver.application.domain.CommonAnswers;
+import com.picksa.picksaserver.application.domain.InterviewAvailable;
+import com.picksa.picksaserver.application.domain.PartAnswers;
+import com.picksa.picksaserver.application.domain.PersonalData;
+import com.picksa.picksaserver.application.repository.converter.AgreementConverter;
+import com.picksa.picksaserver.application.repository.converter.PartConverter;
+import com.picksa.picksaserver.global.domain.Part;
+import jakarta.persistence.AttributeOverride;
+import jakarta.persistence.AttributeOverrides;
+import jakarta.persistence.Column;
+import jakarta.persistence.Convert;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Table(name = "original_applications")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class OriginalApplicationEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column
+    private String timestamp;
+
+    @Column
+    @Convert(converter = AgreementConverter.class)
+    private boolean agreePrivacyCollection;
+
+    @Column
+    private String pathToKnow;
+
+    @Convert(converter = PartConverter.class)
+    private Part part;
+
+    @Embedded
+    private PersonalData personalData;
+
+    @Embedded
+    private CommonAnswers commonAnswer;
+
+    @Embedded
+    @AttributeOverrides({
+            @AttributeOverride(name = "partAnswer1", column = @Column(name = "pm_answer1")),
+            @AttributeOverride(name = "partAnswer2", column = @Column(name = "pm_answer2")),
+            @AttributeOverride(name = "partAnswer3", column = @Column(name = "pm_answer3")),
+            @AttributeOverride(name = "portfolio", column = @Column(name = "pm_portfolio"))
+    })
+    private PartAnswers pm;
+
+    @Embedded
+    @AttributeOverrides({
+            @AttributeOverride(name = "partAnswer1", column = @Column(name = "design_answer1")),
+            @AttributeOverride(name = "partAnswer2", column = @Column(name = "design_answer2")),
+            @AttributeOverride(name = "partAnswer3", column = @Column(name = "design_answer3")),
+            @AttributeOverride(name = "portfolio", column = @Column(name = "design_portfolio"))
+    })
+    private PartAnswers design;
+
+    @Embedded
+    @AttributeOverrides({
+            @AttributeOverride(name = "partAnswer1", column = @Column(name = "frontend_answer1")),
+            @AttributeOverride(name = "partAnswer2", column = @Column(name = "frontend_answer2")),
+            @AttributeOverride(name = "partAnswer3", column = @Column(name = "frontend_answer3")),
+            @AttributeOverride(name = "portfolio", column = @Column(name = "frontend_portfolio"))
+    })
+    private PartAnswers frontend;
+
+    @Embedded
+    @AttributeOverrides({
+            @AttributeOverride(name = "partAnswer1", column = @Column(name = "backend_answer1")),
+            @AttributeOverride(name = "partAnswer2", column = @Column(name = "backend_answer2")),
+            @AttributeOverride(name = "partAnswer3", column = @Column(name = "backend_answer3")),
+            @AttributeOverride(name = "portfolio", column = @Column(name = "backend_portfolio"))
+    })
+    private PartAnswers backend;
+
+    @Embedded
+    private InterviewAvailable interviewAvailable;
+
+}

--- a/src/main/java/com/picksa/picksaserver/application/domain/PartAnswers.java
+++ b/src/main/java/com/picksa/picksaserver/application/domain/PartAnswers.java
@@ -1,0 +1,22 @@
+package com.picksa.picksaserver.application.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.Getter;
+
+@Getter
+@Embeddable
+public class PartAnswers {
+
+    @Column(length = 1000)
+    private String partAnswer1;
+
+    @Column(length = 1000)
+    private String partAnswer2;
+
+    @Column(length = 1000)
+    private String partAnswer3;
+
+    private String portfolio;
+
+}

--- a/src/main/java/com/picksa/picksaserver/application/domain/PersonalData.java
+++ b/src/main/java/com/picksa/picksaserver/application/domain/PersonalData.java
@@ -1,0 +1,26 @@
+package com.picksa.picksaserver.application.domain;
+
+import jakarta.persistence.Embeddable;
+import lombok.Getter;
+
+@Getter
+@Embeddable
+public class PersonalData {
+
+    private String name;
+
+    private String email;
+
+    private String major;
+
+    private String studentId;
+
+    private String multiMajor;
+
+    private String semester;
+
+    private String phone;
+
+    private String gender;
+
+}

--- a/src/main/java/com/picksa/picksaserver/application/dto/response/ApplicationDetailResponse.java
+++ b/src/main/java/com/picksa/picksaserver/application/dto/response/ApplicationDetailResponse.java
@@ -1,0 +1,71 @@
+package com.picksa.picksaserver.application.dto.response;
+
+import com.picksa.picksaserver.applicant.domain.ApplicantEntity;
+import com.picksa.picksaserver.application.domain.ApplicationEntity;
+import com.picksa.picksaserver.global.domain.Part;
+import lombok.Builder;
+
+@Builder
+public record ApplicationDetailResponse(
+        String name,
+        String studentId,
+        String email,
+        String gender,
+        String major,
+        String multiMajor,
+        String phone,
+        String semester,
+        String portfolio,
+        Part part,
+        int generation,
+        String commonAnswer1,
+        String commonAnswer2,
+        String commonAnswer3,
+        String commonAnswer4,
+        String commonAnswer5,
+        String partAnswer1,
+        String partAnswer2,
+        String partAnswer3,
+        String interviewAvailableTimes
+) {
+    public static ApplicationDetailResponse from(ApplicationEntity application) {
+        return ApplicationDetailResponse.builder()
+                .name(application.getPersonalData().getName())
+                .studentId(application.getPersonalData().getStudentId())
+                .email(application.getPersonalData().getEmail())
+                .gender(application.getPersonalData().getGender())
+                .major(application.getPersonalData().getMajor())
+                .multiMajor(application.getPersonalData().getMultiMajor())
+                .phone(application.getPersonalData().getPhone())
+                .semester(application.getPersonalData().getSemester())
+                .part(application.getPart())
+                .generation(application.getGeneration())
+                .commonAnswer1(application.getCommonAnswers().getCommonAnswer1())
+                .commonAnswer2(application.getCommonAnswers().getCommonAnswer2())
+                .commonAnswer3(application.getCommonAnswers().getCommonAnswer3())
+                .commonAnswer4(application.getCommonAnswers().getCommonAnswer4())
+                .commonAnswer5(application.getCommonAnswers().getCommonAnswer5())
+                .partAnswer1(application.getPartAnswers().getPartAnswer1())
+                .partAnswer2(application.getPartAnswers().getPartAnswer2())
+                .partAnswer3(application.getPartAnswers().getPartAnswer3())
+                .interviewAvailableTimes(application.getInterviewAvailableTimes())
+                .build();
+    }
+
+    public ApplicantEntity toEntity() {
+        return ApplicantEntity.builder()
+                .name(name)
+                .studentId(studentId)
+                .semester(semester)
+                .gender(gender)
+                .phone(phone)
+                .email(email)
+                .major(major)
+                .multiMajor(multiMajor)
+                .part(part)
+                .generation(generation)
+                .interviewAvailableTimes(interviewAvailableTimes)
+                .build();
+    }
+
+}

--- a/src/main/java/com/picksa/picksaserver/application/dto/response/ApplicationSyncResponse.java
+++ b/src/main/java/com/picksa/picksaserver/application/dto/response/ApplicationSyncResponse.java
@@ -1,0 +1,15 @@
+package com.picksa.picksaserver.application.dto.response;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record ApplicationSyncResponse(
+        LocalDateTime until,
+        List<ApplicationDetailResponse> applications
+) {
+
+    public static ApplicationSyncResponse of(LocalDateTime until, List<ApplicationDetailResponse> responses) {
+        return new ApplicationSyncResponse(until, responses);
+    }
+
+}

--- a/src/main/java/com/picksa/picksaserver/application/repository/ApplicationQueryRepository.java
+++ b/src/main/java/com/picksa/picksaserver/application/repository/ApplicationQueryRepository.java
@@ -1,0 +1,14 @@
+package com.picksa.picksaserver.application.repository;
+
+import com.picksa.picksaserver.application.dto.response.ApplicationDetailResponse;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public interface ApplicationQueryRepository {
+
+    List<ApplicationDetailResponse> getApplicationCreatedBetween(LocalDateTime after, LocalDateTime until);
+
+    List<ApplicationDetailResponse> getApplicationsUntil(LocalDateTime until);
+
+}

--- a/src/main/java/com/picksa/picksaserver/application/repository/ApplicationQueryRepositoryImpl.java
+++ b/src/main/java/com/picksa/picksaserver/application/repository/ApplicationQueryRepositoryImpl.java
@@ -1,0 +1,97 @@
+package com.picksa.picksaserver.application.repository;
+
+import com.picksa.picksaserver.application.dto.response.ApplicationDetailResponse;
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static com.picksa.picksaserver.application.domain.QApplicationEntity.applicationEntity;
+
+
+@Repository
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ApplicationQueryRepositoryImpl implements ApplicationQueryRepository {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public List<ApplicationDetailResponse> getApplicationCreatedBetween(LocalDateTime after, LocalDateTime until) {
+        return jpaQueryFactory.select(Projections.constructor(
+                        ApplicationDetailResponse.class,
+                        applicationEntity.personalData.name,
+                        applicationEntity.personalData.studentId,
+                        applicationEntity.personalData.email,
+                        applicationEntity.personalData.gender,
+                        applicationEntity.personalData.major,
+                        applicationEntity.personalData.multiMajor,
+                        applicationEntity.personalData.phone,
+                        applicationEntity.personalData.semester,
+                        applicationEntity.partAnswers.portfolio,
+                        applicationEntity.part,
+                        applicationEntity.generation,
+                        applicationEntity.commonAnswers.commonAnswer1,
+                        applicationEntity.commonAnswers.commonAnswer2,
+                        applicationEntity.commonAnswers.commonAnswer3,
+                        applicationEntity.commonAnswers.commonAnswer4,
+                        applicationEntity.commonAnswers.commonAnswer5,
+                        applicationEntity.partAnswers.partAnswer1,
+                        applicationEntity.partAnswers.partAnswer2,
+                        applicationEntity.partAnswers.partAnswer3,
+                        applicationEntity.interviewAvailableTimes
+                ))
+                .from(applicationEntity)
+                .where(
+                        applicationEntity.createdAt.after(after)
+                                .orAllOf(applicationEntity.createdAt.before(until),
+                                        applicationEntity.createdAt.eq(until)
+                                )
+                )
+                .orderBy(
+                        applicationEntity.createdAt.desc()
+                )
+                .fetch();
+    }
+
+    @Override
+    public List<ApplicationDetailResponse> getApplicationsUntil(LocalDateTime until) {
+        return jpaQueryFactory.select(Projections.constructor(
+                        ApplicationDetailResponse.class,
+                        applicationEntity.personalData.name,
+                        applicationEntity.personalData.studentId,
+                        applicationEntity.personalData.email,
+                        applicationEntity.personalData.gender,
+                        applicationEntity.personalData.major,
+                        applicationEntity.personalData.multiMajor,
+                        applicationEntity.personalData.phone,
+                        applicationEntity.personalData.semester,
+                        applicationEntity.partAnswers.portfolio,
+                        applicationEntity.part,
+                        applicationEntity.generation,
+                        applicationEntity.commonAnswers.commonAnswer1,
+                        applicationEntity.commonAnswers.commonAnswer2,
+                        applicationEntity.commonAnswers.commonAnswer3,
+                        applicationEntity.commonAnswers.commonAnswer4,
+                        applicationEntity.commonAnswers.commonAnswer5,
+                        applicationEntity.partAnswers.partAnswer1,
+                        applicationEntity.partAnswers.partAnswer2,
+                        applicationEntity.partAnswers.partAnswer3,
+                        applicationEntity.interviewAvailableTimes
+                ))
+                .from(applicationEntity)
+                .where(
+                        applicationEntity.createdAt.before(until)
+                                .or(applicationEntity.createdAt.eq(until))
+                )
+                .orderBy(
+                        applicationEntity.createdAt.desc()
+                )
+                .fetch();
+    }
+
+}

--- a/src/main/java/com/picksa/picksaserver/application/repository/ApplicationRepository.java
+++ b/src/main/java/com/picksa/picksaserver/application/repository/ApplicationRepository.java
@@ -1,0 +1,10 @@
+package com.picksa.picksaserver.application.repository;
+
+import com.picksa.picksaserver.application.domain.ApplicationEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ApplicationRepository extends JpaRepository<ApplicationEntity, Long>, ApplicationQueryRepository {
+
+    ApplicationEntity findTopByOrderByOriginalIdDesc();
+
+}

--- a/src/main/java/com/picksa/picksaserver/application/repository/OriginalApplicationRepository.java
+++ b/src/main/java/com/picksa/picksaserver/application/repository/OriginalApplicationRepository.java
@@ -1,0 +1,12 @@
+package com.picksa.picksaserver.application.repository;
+
+import com.picksa.picksaserver.application.domain.OriginalApplicationEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface OriginalApplicationRepository extends JpaRepository<OriginalApplicationEntity, Long> {
+
+    List<OriginalApplicationEntity> findByIdAfter(Long id);
+
+}

--- a/src/main/java/com/picksa/picksaserver/application/repository/converter/AgreementConverter.java
+++ b/src/main/java/com/picksa/picksaserver/application/repository/converter/AgreementConverter.java
@@ -1,0 +1,26 @@
+package com.picksa.picksaserver.application.repository.converter;
+
+import jakarta.persistence.AttributeConverter;
+
+public class AgreementConverter implements AttributeConverter<Boolean, String> {
+
+    private static final String YES = "예";
+    private static final String NO = "아니오";
+
+    @Override
+    public String convertToDatabaseColumn(Boolean isAgreed) {
+        if (isAgreed) {
+            return YES;
+        }
+        return NO;
+    }
+
+    @Override
+    public Boolean convertToEntityAttribute(String s) {
+        if (s.equals(YES)) {
+            return true;
+        }
+        return false;
+    }
+
+}

--- a/src/main/java/com/picksa/picksaserver/application/repository/converter/PartConverter.java
+++ b/src/main/java/com/picksa/picksaserver/application/repository/converter/PartConverter.java
@@ -1,0 +1,26 @@
+package com.picksa.picksaserver.application.repository.converter;
+
+import com.picksa.picksaserver.global.domain.Part;
+import io.micrometer.common.util.StringUtils;
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+@Converter
+public class PartConverter implements AttributeConverter<Part, String> {
+
+    @Override
+    public String convertToDatabaseColumn(Part attribute) {
+        if(attribute == null) return null;
+
+        return attribute.getPartName();
+    }
+
+    @Override
+    public Part convertToEntityAttribute(String name) {
+        if(StringUtils.isBlank(name))
+            return null;
+
+        return Part.getPartFromName(name);
+    }
+
+}

--- a/src/main/java/com/picksa/picksaserver/application/service/ApplicationConvertService.java
+++ b/src/main/java/com/picksa/picksaserver/application/service/ApplicationConvertService.java
@@ -1,0 +1,138 @@
+package com.picksa.picksaserver.application.service;
+
+import com.picksa.picksaserver.applicant.domain.AnswerEntity;
+import com.picksa.picksaserver.applicant.domain.ApplicantEntity;
+import com.picksa.picksaserver.applicant.repository.AnswerRepository;
+import com.picksa.picksaserver.applicant.repository.ApplicantRepository;
+import com.picksa.picksaserver.application.dto.response.ApplicationDetailResponse;
+import com.picksa.picksaserver.application.dto.response.ApplicationSyncResponse;
+import com.picksa.picksaserver.global.domain.Generation;
+import com.picksa.picksaserver.global.domain.Part;
+import com.picksa.picksaserver.question.QuestionEntity;
+import com.picksa.picksaserver.question.repository.QuestionRepository;
+import com.picksa.picksaserver.sync.domain.SyncRequestLog;
+import com.picksa.picksaserver.sync.repository.SyncLogRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ApplicationConvertService {
+
+    private final ApplicationService applicationService;
+    private final SyncLogRepository syncLogRepository;
+    private final QuestionRepository questionRepository;
+    private final ApplicantRepository applicantRepository;
+    private final AnswerRepository answerRepository;
+
+    // TODO: 2024-02-12 코드 가독성 개선
+    @Transactional
+    public void convertApplicationToApplicant() {
+        SyncRequestLog lastRequestLog = syncLogRepository.getFirstByOrderByCreatedAtDesc();
+        int generation = Generation.getGenerationOfThisYear();
+        List<QuestionEntity> questionEntities = questionRepository.findDeterminedQuestionsByGeneration(generation);
+        System.out.println("questionEntities.size() = " + questionEntities.size());
+        if (questionEntities.isEmpty()) {
+            throw new IllegalArgumentException("이번 기수의 질문이 존재하지 않습니다.");
+        }
+
+        // 올해의 질문 Map 구조로 변환
+        Map<Integer, Map<Part, QuestionEntity>> questions = new HashMap<>();
+        for (QuestionEntity question : questionEntities) {
+
+            if (!questions.containsKey(question.getSequence())) {
+                questions.put(question.getSequence(), new HashMap<Part, QuestionEntity>());
+            }
+
+            questions.get(question.getSequence()).put(question.getTag().getPart(), question);
+        }
+
+        for (Map.Entry<Integer, Map<Part, QuestionEntity>> sequence : questions.entrySet()) {
+            System.out.println(sequence.getKey() + " : " + sequence.getValue());
+        }
+
+
+        ApplicationSyncResponse response;
+        if (lastRequestLog == null) {
+            response = applicationService.getAllApplications();
+        } else {
+            response = applicationService.getApplicationsAfter(lastRequestLog.getProcessedAt());
+        }
+        System.out.println("response = " + response.applications().size());
+        SyncRequestLog newLog = SyncRequestLog.builder().processedAt(response.until()).build();
+        syncLogRepository.save(newLog);
+
+        // Application -> Applicant 변환
+        List<ApplicantEntity> applicants = new ArrayList<>();
+        List<AnswerEntity> answers = new ArrayList<>();
+        for (ApplicationDetailResponse application : response.applications()) {
+            ApplicantEntity applicant = application.toEntity();
+            applicants.add(applicant);
+
+            // 질문 답변 리스트로 변환
+            List<String> applicationAnswers = collectAnswersInList(application);
+            System.out.println("applicationAnswers.size() = " + applicationAnswers.size());
+            int index = 0;
+            Part applicationPart = application.part();
+            for (String applicationAnswer : applicationAnswers) {
+                if (applicationAnswer == null) {
+                    index++;
+                    continue;
+                }
+
+                if (questions.get(index+1).containsKey(Part.ALL)) {
+                    QuestionEntity question = questions.get(index + 1).get(Part.ALL);
+                    String answerContent = applicationAnswers.get(index);
+                    answers.add(createAnswerEntity(question, answerContent, applicant));
+                } else if (questions.get(index + 1).containsKey(application.part())) {
+                    QuestionEntity question = questions.get(index + 1).get(applicationPart);
+                    String answerContent = applicationAnswers.get(index);
+                    answers.add(createAnswerEntity(question, answerContent, applicant));
+                } else {
+                    index++;
+                    continue;
+                }
+
+                index++;
+            }
+
+        }
+
+        // 저장
+        applicantRepository.saveAll(applicants);
+        answerRepository.saveAll(answers);
+
+    }
+
+    // TODO: 2024-01-21 응집도 개선 (메서드 분리)
+    private List<String> collectAnswersInList(ApplicationDetailResponse application) {
+        List<String> applicationAnswers = new ArrayList<>();
+        applicationAnswers.add(application.commonAnswer1());
+        applicationAnswers.add(application.commonAnswer2());
+        applicationAnswers.add(application.commonAnswer3());
+        applicationAnswers.add(application.commonAnswer4());
+        applicationAnswers.add(application.commonAnswer5());
+        applicationAnswers.add(application.partAnswer1());
+        applicationAnswers.add(application.partAnswer2());
+        applicationAnswers.add(application.partAnswer3());
+
+        return applicationAnswers;
+    }
+
+    private AnswerEntity createAnswerEntity(QuestionEntity question, String answerContent, ApplicantEntity applicant) {
+        return AnswerEntity.builder()
+                .question(question)
+                .content(answerContent)
+                .applicant(applicant)
+                .build();
+    }
+
+}

--- a/src/main/java/com/picksa/picksaserver/application/service/ApplicationService.java
+++ b/src/main/java/com/picksa/picksaserver/application/service/ApplicationService.java
@@ -1,0 +1,33 @@
+package com.picksa.picksaserver.application.service;
+
+import com.picksa.picksaserver.application.dto.response.ApplicationDetailResponse;
+import com.picksa.picksaserver.application.dto.response.ApplicationSyncResponse;
+import com.picksa.picksaserver.application.repository.ApplicationRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ApplicationService {
+
+    private final ApplicationRepository applicationRepository;
+
+    public ApplicationSyncResponse getApplicationsAfter(LocalDateTime after) {
+        LocalDateTime until = LocalDateTime.now();
+        List<ApplicationDetailResponse> applicationDetailResponses = applicationRepository.getApplicationCreatedBetween(after, until);
+
+        return ApplicationSyncResponse.of(until, applicationDetailResponses);
+    }
+
+    public ApplicationSyncResponse getAllApplications() {
+        LocalDateTime until = LocalDateTime.now();
+        List<ApplicationDetailResponse> applicationDetailResponses = applicationRepository.getApplicationsUntil(until);
+        return ApplicationSyncResponse.of(until, applicationDetailResponses);
+    }
+
+}

--- a/src/main/java/com/picksa/picksaserver/application/service/OriginalApplicationConvertService.java
+++ b/src/main/java/com/picksa/picksaserver/application/service/OriginalApplicationConvertService.java
@@ -1,0 +1,61 @@
+package com.picksa.picksaserver.application.service;
+
+
+import com.picksa.picksaserver.applicant.domain.InterviewScheduleEntity;
+import com.picksa.picksaserver.applicant.repository.InterviewScheduleRepository;
+import com.picksa.picksaserver.application.domain.ApplicationEntity;
+import com.picksa.picksaserver.application.service.converter.InterviewAvailableConverter;
+import com.picksa.picksaserver.application.domain.OriginalApplicationEntity;
+import com.picksa.picksaserver.application.service.converter.ApplicationConverterProvider;
+import com.picksa.picksaserver.application.service.converter.ApplicationCoverter;
+import com.picksa.picksaserver.application.repository.ApplicationRepository;
+import com.picksa.picksaserver.application.repository.OriginalApplicationRepository;
+import com.picksa.picksaserver.global.domain.Generation;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class OriginalApplicationConvertService {
+
+    private final OriginalApplicationRepository originalApplicationRepository;
+    private final InterviewScheduleRepository interviewScheduleRepository;
+    private final ApplicationRepository applicationRepository;
+
+    private final ApplicationConverterProvider applicationConverterProvider;
+    private final InterviewAvailableConverter interviewAvailableConverter;
+
+    @Transactional
+    public void convertOriginalToApplication() {
+
+        ApplicationEntity lastApplication = applicationRepository.findTopByOrderByOriginalIdDesc();
+        Long lastOriginalId = 0L;
+        if (lastApplication != null) {
+            lastOriginalId = lastApplication.getOriginalId();
+        }
+
+        int generation = Generation.getGenerationOfThisYear();
+        List<InterviewScheduleEntity> interviewSchedules = interviewScheduleRepository.findByGenerationOrderByDate(generation);
+
+        List<OriginalApplicationEntity> originals = originalApplicationRepository.findByIdAfter(lastOriginalId);
+
+        List<ApplicationEntity> applicationsToSave = new ArrayList<>();
+        for (OriginalApplicationEntity original : originals) {
+            ApplicationCoverter applicationCoverter = applicationConverterProvider.provideConverter(original.getPart());
+            String formattedInterviewAvailable = interviewAvailableConverter.formatTotalToBinary(original.getInterviewAvailable(), interviewSchedules);
+            System.out.println("formattedInterviewAvailable = " + formattedInterviewAvailable);
+            ApplicationEntity application = applicationCoverter.convertOriginalToApplication(original, formattedInterviewAvailable, original.getId(), generation);
+
+            applicationsToSave.add(application);
+        }
+
+        applicationRepository.saveAll(applicationsToSave);
+    }
+
+}

--- a/src/main/java/com/picksa/picksaserver/application/service/converter/ApplicationConverterProvider.java
+++ b/src/main/java/com/picksa/picksaserver/application/service/converter/ApplicationConverterProvider.java
@@ -1,0 +1,25 @@
+package com.picksa.picksaserver.application.service.converter;
+
+import com.picksa.picksaserver.global.domain.Part;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@Component
+public class ApplicationConverterProvider {
+
+    private final Map<Part, ApplicationCoverter> converters;
+
+    public ApplicationConverterProvider(Set<ApplicationCoverter> converters) {
+        this.converters = converters.stream()
+                .collect(Collectors.toUnmodifiableMap(ApplicationCoverter::part, Function.identity()));
+    }
+
+    public ApplicationCoverter provideConverter(Part part) {
+        return converters.get(part);
+    }
+
+}

--- a/src/main/java/com/picksa/picksaserver/application/service/converter/ApplicationCoverter.java
+++ b/src/main/java/com/picksa/picksaserver/application/service/converter/ApplicationCoverter.java
@@ -1,0 +1,14 @@
+package com.picksa.picksaserver.application.service.converter;
+
+
+import com.picksa.picksaserver.application.domain.ApplicationEntity;
+import com.picksa.picksaserver.application.domain.OriginalApplicationEntity;
+import com.picksa.picksaserver.global.domain.Part;
+
+public interface ApplicationCoverter {
+
+    Part part();
+
+    ApplicationEntity convertOriginalToApplication(OriginalApplicationEntity original, String interviewAvailables, Long originalId, int generation);
+
+}

--- a/src/main/java/com/picksa/picksaserver/application/service/converter/BackendApplicationConverter.java
+++ b/src/main/java/com/picksa/picksaserver/application/service/converter/BackendApplicationConverter.java
@@ -1,0 +1,31 @@
+package com.picksa.picksaserver.application.service.converter;
+
+import com.picksa.picksaserver.application.domain.ApplicationEntity;
+import com.picksa.picksaserver.application.domain.OriginalApplicationEntity;
+import com.picksa.picksaserver.global.domain.Part;
+import org.springframework.stereotype.Component;
+
+@Component
+public class BackendApplicationConverter implements ApplicationCoverter {
+
+    @Override
+    public Part part() {
+        return Part.BACKEND;
+    }
+
+    @Override
+    public ApplicationEntity convertOriginalToApplication(OriginalApplicationEntity original, String interviewAvailables, Long originalId, int generation) {
+
+        return ApplicationEntity.builder()
+                .agreePrivacyCollection(original.isAgreePrivacyCollection())
+                .part(original.getPart())
+                .generation(generation)
+                .personalData(original.getPersonalData())
+                .commonAnswers(original.getCommonAnswer())
+                .partAnswers(original.getBackend())
+                .interviewAvailableTimes(interviewAvailables)
+                .originalId(originalId)
+                .build();
+    }
+
+}

--- a/src/main/java/com/picksa/picksaserver/application/service/converter/DesignApplicationConverter.java
+++ b/src/main/java/com/picksa/picksaserver/application/service/converter/DesignApplicationConverter.java
@@ -1,0 +1,30 @@
+package com.picksa.picksaserver.application.service.converter;
+
+
+import com.picksa.picksaserver.application.domain.ApplicationEntity;
+import com.picksa.picksaserver.application.domain.OriginalApplicationEntity;
+import com.picksa.picksaserver.global.domain.Part;
+import org.springframework.stereotype.Component;
+
+@Component
+public class DesignApplicationConverter implements ApplicationCoverter {
+    @Override
+    public Part part() {
+        return Part.DESIGN;
+    }
+
+    @Override
+    public ApplicationEntity convertOriginalToApplication(OriginalApplicationEntity original, String interviewAvailables, Long originalId, int generation) {
+
+        return ApplicationEntity.builder()
+                .agreePrivacyCollection(original.isAgreePrivacyCollection())
+                .part(original.getPart())
+                .generation(generation)
+                .personalData(original.getPersonalData())
+                .commonAnswers(original.getCommonAnswer())
+                .partAnswers(original.getDesign())
+                .interviewAvailableTimes(interviewAvailables)
+                .originalId(originalId)
+                .build();
+    }
+}

--- a/src/main/java/com/picksa/picksaserver/application/service/converter/FrontendApplicationConverter.java
+++ b/src/main/java/com/picksa/picksaserver/application/service/converter/FrontendApplicationConverter.java
@@ -1,0 +1,30 @@
+package com.picksa.picksaserver.application.service.converter;
+
+import com.picksa.picksaserver.application.domain.ApplicationEntity;
+import com.picksa.picksaserver.application.domain.OriginalApplicationEntity;
+import com.picksa.picksaserver.global.domain.Part;
+import org.springframework.stereotype.Component;
+
+@Component
+public class FrontendApplicationConverter implements ApplicationCoverter {
+    @Override
+    public Part part() {
+        return Part.FRONTEND;
+    }
+
+    @Override
+    public ApplicationEntity convertOriginalToApplication(OriginalApplicationEntity original, String interviewAvailables, Long originalId, int generation) {
+
+        // TODO: 2024-01-20 기수 자동 적용
+        return ApplicationEntity.builder()
+                .agreePrivacyCollection(original.isAgreePrivacyCollection())
+                .part(original.getPart())
+                .generation(generation)
+                .personalData(original.getPersonalData())
+                .commonAnswers(original.getCommonAnswer())
+                .partAnswers(original.getFrontend())
+                .interviewAvailableTimes(interviewAvailables)
+                .originalId(originalId)
+                .build();
+    }
+}

--- a/src/main/java/com/picksa/picksaserver/application/service/converter/InterviewAvailableConverter.java
+++ b/src/main/java/com/picksa/picksaserver/application/service/converter/InterviewAvailableConverter.java
@@ -1,0 +1,98 @@
+package com.picksa.picksaserver.application.service.converter;
+
+import com.picksa.picksaserver.applicant.domain.InterviewScheduleEntity;
+import com.picksa.picksaserver.application.domain.InterviewAvailable;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+import java.time.Duration;
+import java.time.LocalTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Component
+public class InterviewAvailableConverter {
+
+    private static final String BLANK = "";
+    private static final long TIME_UNIT = 60;
+    private static final char AVAILABLE = '1';
+
+    public String formatTotalToBinary(InterviewAvailable interviewAvailable, List<InterviewScheduleEntity> interviewSchedules) {
+
+        List<String> interviewAvailables = new ArrayList<>();
+        interviewAvailables.add(interviewAvailable.getDay1());
+        interviewAvailables.add(interviewAvailable.getDay2());
+        interviewAvailables.add(interviewAvailable.getDay3());
+
+        StringBuilder stringBuilder = new StringBuilder();
+
+        for(int i = 0; i<interviewSchedules.size(); i++) {
+            stringBuilder.append(formatDayToBinary(interviewAvailables.get(i), interviewSchedules.get(i)));
+        }
+
+        return stringBuilder.toString();
+    }
+
+
+    private String formatDayToBinary(String original, InterviewScheduleEntity schedule) {
+
+        String bianaryFormatOfDay = getBaseFormat(schedule);
+
+        if (!StringUtils.hasText(original)) {
+            return bianaryFormatOfDay;
+        }
+
+        String[] choices = splitChoiceOriginal(original);
+
+        for(String choice:choices) {
+            LocalTime startOfTime = getStartOfTime(choice);
+            int indexOfTime = getIndexOfTime(schedule.getStartAt(), startOfTime);
+            bianaryFormatOfDay = setTimeAvailable(bianaryFormatOfDay, indexOfTime);
+        }
+
+        return bianaryFormatOfDay;
+    }
+
+    private String getBaseFormat(InterviewScheduleEntity schedule) {
+        Duration duration = Duration.between(schedule.getStartAt(), schedule.getFinishAt());
+        System.out.println("duration.toMinutes() = " + duration.toMinutes());
+        long length = duration.toMinutes() / TIME_UNIT;
+        System.out.println(length);
+        String baseFormat = "0".repeat((int) length);
+
+        return baseFormat;
+    }
+
+    private String[] splitChoiceOriginal(String choice) {
+        String blankRemoved = choice.replaceAll(" ", BLANK);
+        String[] splitted = blankRemoved.split(",");
+
+        return splitted;
+    }
+
+    private LocalTime getStartOfTime(String choice) {
+        String[] times = choice.split("-");
+        String[] timeElements = times[0].split(":");
+        int hour = Integer.parseInt(timeElements[0]);
+        int minute = Integer.parseInt(timeElements[1]);
+
+        return LocalTime.of(hour, minute);
+    }
+
+    private int getIndexOfTime(LocalTime startOfDay, LocalTime time) {
+        Duration duration = Duration.between(startOfDay, time);
+        System.out.println("duration = " + duration.toMinutes());
+        long index = duration.toMinutes() / TIME_UNIT;
+        System.out.println("index = " + index);
+        return (int) index;
+    }
+
+    private String setTimeAvailable(String formattedString, int index) {
+        StringBuilder stringBuilder = new StringBuilder(formattedString);
+        stringBuilder.setCharAt(index, AVAILABLE);
+
+        return stringBuilder.toString();
+    }
+
+}
+

--- a/src/main/java/com/picksa/picksaserver/application/service/converter/PmApplicationConverter.java
+++ b/src/main/java/com/picksa/picksaserver/application/service/converter/PmApplicationConverter.java
@@ -1,0 +1,31 @@
+package com.picksa.picksaserver.application.service.converter;
+
+
+import com.picksa.picksaserver.application.domain.ApplicationEntity;
+import com.picksa.picksaserver.application.domain.OriginalApplicationEntity;
+import com.picksa.picksaserver.global.domain.Part;
+import org.springframework.stereotype.Component;
+
+@Component
+public class PmApplicationConverter implements ApplicationCoverter {
+
+    @Override
+    public Part part() {
+        return Part.PM;
+    }
+
+    @Override
+    public ApplicationEntity convertOriginalToApplication(OriginalApplicationEntity original, String interviewAvailables, Long originalId, int generation) {
+
+        return ApplicationEntity.builder()
+                .agreePrivacyCollection(original.isAgreePrivacyCollection())
+                .part(original.getPart())
+                .generation(generation)
+                .personalData(original.getPersonalData())
+                .commonAnswers(original.getCommonAnswer())
+                .partAnswers(original.getPm())
+                .interviewAvailableTimes(interviewAvailables)
+                .originalId(originalId)
+                .build();
+    }
+}

--- a/src/main/java/com/picksa/picksaserver/auth/oAuth/service/OAuthService.java
+++ b/src/main/java/com/picksa/picksaserver/auth/oAuth/service/OAuthService.java
@@ -1,8 +1,8 @@
 package com.picksa.picksaserver.auth.oAuth.service;
 
+import com.picksa.picksaserver.auth.exception.AuthenticationUserNotExistException;
 import com.picksa.picksaserver.auth.oAuth.dto.OAuthUserInfoResponse;
 import com.picksa.picksaserver.auth.oAuth.dto.SignInResponse;
-import com.picksa.picksaserver.auth.exception.AuthenticationUserNotExistException;
 import com.picksa.picksaserver.global.auth.JwtProvider;
 import com.picksa.picksaserver.user.UserEntity;
 import com.picksa.picksaserver.user.repository.UserRepository;

--- a/src/main/java/com/picksa/picksaserver/evaluation/service/EvaluationService.java
+++ b/src/main/java/com/picksa/picksaserver/evaluation/service/EvaluationService.java
@@ -14,9 +14,6 @@ import com.picksa.picksaserver.global.domain.Generation;
 import com.picksa.picksaserver.user.Position;
 import com.picksa.picksaserver.user.UserEntity;
 import com.picksa.picksaserver.user.repository.UserRepository;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.core.Authentication;
@@ -26,11 +23,12 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Objects;
+import java.util.stream.Collectors;
 
 import static com.picksa.picksaserver.evaluation.exception.EvaluationExceptionMessage.ALREADY_EVALUATED;
+import static com.picksa.picksaserver.evaluation.exception.EvaluationExceptionMessage.UPDATE_NOT_PERMITTED;
 import static com.picksa.picksaserver.evaluation.exception.EvaluationExceptionMessage.USER_NOT_PART_LEADER;
 import static com.picksa.picksaserver.evaluation.exception.EvaluationExceptionMessage.USER_PART_MISMATCHED;
-import static com.picksa.picksaserver.evaluation.exception.EvaluationExceptionMessage.UPDATE_NOT_PERMITTED;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/com/picksa/picksaserver/global/config/JpaConfig.java
+++ b/src/main/java/com/picksa/picksaserver/global/config/JpaConfig.java
@@ -1,0 +1,10 @@
+package com.picksa.picksaserver.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaConfig {
+
+}

--- a/src/main/java/com/picksa/picksaserver/global/config/WebSecurityConfig.java
+++ b/src/main/java/com/picksa/picksaserver/global/config/WebSecurityConfig.java
@@ -37,6 +37,7 @@ public class WebSecurityConfig {
                         .requestMatchers(new AntPathRequestMatcher("/error")).permitAll()
                         .requestMatchers(new AntPathRequestMatcher("/api/v1/auth/**")).permitAll()
                         .requestMatchers(new AntPathRequestMatcher("/api/v1/tags/**")).permitAll()
+                        .requestMatchers(new AntPathRequestMatcher("/api/v1/applications/**")).permitAll()
                         .requestMatchers(new AntPathRequestMatcher("/api/v1/evaluations/final/**", HttpMethod.PATCH.name())).hasRole(Position.PART_LEADER.name())
                         .requestMatchers(new AntPathRequestMatcher("/api/v1/interview/schedules",HttpMethod.POST.name())).hasRole(Position.PRESIDENT.name())
                         .requestMatchers(new AntPathRequestMatcher("/api/v1/interview/schedules",HttpMethod.PATCH.name())).hasRole(Position.PRESIDENT.name())

--- a/src/main/java/com/picksa/picksaserver/global/domain/BaseEntity.java
+++ b/src/main/java/com/picksa/picksaserver/global/domain/BaseEntity.java
@@ -1,0 +1,26 @@
+package com.picksa.picksaserver.global.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseEntity {
+
+    @Column(name = "created_at", nullable = false, updatable = false, columnDefinition = "TIMESTAMP(6)")
+    @CreatedDate
+    LocalDateTime createdAt;
+
+    @Column(name = "updated_at", nullable = false, columnDefinition = "TIMESTAMP(6)")
+    @LastModifiedDate
+    LocalDateTime updatedAt;
+
+}

--- a/src/main/java/com/picksa/picksaserver/global/domain/Part.java
+++ b/src/main/java/com/picksa/picksaserver/global/domain/Part.java
@@ -2,6 +2,8 @@ package com.picksa.picksaserver.global.domain;
 
 import lombok.Getter;
 
+import java.util.Arrays;
+
 @Getter
 public enum Part {
 
@@ -19,6 +21,13 @@ public enum Part {
 
     public static Part from(String lowerCase) {
         return Part.valueOf(lowerCase.toUpperCase());
+    }
+
+    public static Part getPartFromName(String name) {
+        return Arrays.stream(Part.values())
+                .filter(v -> v.getPartName().equals(name))
+                .findAny()
+                .orElseThrow(() -> new IllegalArgumentException(String.format("이름과 일치하는 Part가 없습니다: %s", name)));
     }
 
 }

--- a/src/main/java/com/picksa/picksaserver/global/response/DefaultErrorResponse.java
+++ b/src/main/java/com/picksa/picksaserver/global/response/DefaultErrorResponse.java
@@ -1,6 +1,5 @@
 package com.picksa.picksaserver.global.response;
 
-import com.picksa.picksaserver.global.exception.ErrorCode;
 import lombok.Getter;
 
 @Getter

--- a/src/main/java/com/picksa/picksaserver/question/repository/QuestionQueryRepository.java
+++ b/src/main/java/com/picksa/picksaserver/question/repository/QuestionQueryRepository.java
@@ -1,6 +1,7 @@
 package com.picksa.picksaserver.question.repository;
 
 import com.picksa.picksaserver.global.domain.Part;
+import com.picksa.picksaserver.question.QuestionEntity;
 import com.picksa.picksaserver.question.QuestionOrderCondition;
 import com.picksa.picksaserver.question.dto.response.QuestionResponse;
 
@@ -11,4 +12,7 @@ public interface QuestionQueryRepository {
     List<QuestionResponse> findAllQuestionsByPart(Part part, QuestionOrderCondition condition, int generation);
 
     List<QuestionResponse> findDeterminedQuestionsByPart(Part part, int generation);
+
+    List<QuestionEntity> findDeterminedQuestionsByGeneration(int generation);
+
 }

--- a/src/main/java/com/picksa/picksaserver/question/repository/QuestionRepository.java
+++ b/src/main/java/com/picksa/picksaserver/question/repository/QuestionRepository.java
@@ -4,4 +4,5 @@ import com.picksa.picksaserver.question.QuestionEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface QuestionRepository extends JpaRepository<QuestionEntity, Long>, QuestionQueryRepository {
+
 }

--- a/src/main/java/com/picksa/picksaserver/question/repository/QuestionRepositoryImpl.java
+++ b/src/main/java/com/picksa/picksaserver/question/repository/QuestionRepositoryImpl.java
@@ -1,6 +1,7 @@
 package com.picksa.picksaserver.question.repository;
 
 import com.picksa.picksaserver.global.domain.Part;
+import com.picksa.picksaserver.question.QuestionEntity;
 import com.picksa.picksaserver.question.QuestionOrderCondition;
 import com.picksa.picksaserver.question.dto.response.QuestionResponse;
 import com.querydsl.core.types.Projections;
@@ -78,6 +79,19 @@ public class QuestionRepositoryImpl implements QuestionQueryRepository {
                             questionEntity.tag.part.asc(),
                             questionEntity.sequence.asc())
                     .fetch();
+    }
+
+    @Override
+    public List<QuestionEntity> findDeterminedQuestionsByGeneration(int generation) {
+        return jpaQueryFactory.selectFrom(questionEntity)
+                .where(
+                        questionEntity.tag.generation.eq(generation),
+                        questionEntity.isDetermined.eq(true),
+                        questionEntity.deletedAt.isNull()
+                )
+                .orderBy(
+                        questionEntity.sequence.asc())
+                .fetch();
     }
 
 }

--- a/src/main/java/com/picksa/picksaserver/sync/domain/SyncRequestLog.java
+++ b/src/main/java/com/picksa/picksaserver/sync/domain/SyncRequestLog.java
@@ -1,0 +1,35 @@
+package com.picksa.picksaserver.sync.domain;
+
+import com.picksa.picksaserver.global.domain.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Table(name = "sync_request_logs")
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class SyncRequestLog extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "processed_at", nullable = false, columnDefinition = "TIMESTAMP(6)")
+    private LocalDateTime processedAt;
+
+    @Builder
+    public SyncRequestLog(LocalDateTime processedAt) {
+        this.processedAt = processedAt;
+    }
+
+}

--- a/src/main/java/com/picksa/picksaserver/sync/repository/SyncLogRepository.java
+++ b/src/main/java/com/picksa/picksaserver/sync/repository/SyncLogRepository.java
@@ -1,0 +1,10 @@
+package com.picksa.picksaserver.sync.repository;
+
+import com.picksa.picksaserver.sync.domain.SyncRequestLog;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SyncLogRepository extends JpaRepository<SyncRequestLog, Long> {
+
+    SyncRequestLog getFirstByOrderByCreatedAtDesc();
+
+}


### PR DESCRIPTION
## 📃 Describe
<!-- 무엇을 위한 PR인지 간략하게 적어주세요-->
설계가 변경되어 지원서 원본(OriginalApplication)->Application 형식으로 변환하여 저장하는 기능을 `picksa-server`에 구현했습니다.

### 🦁 Changes
<!-- 변경 사항을 적어주세요 -->
- [x] `@EnableJpaAuditing` 분리
- [x] `ApplicationEntity` 생성자 수정
- [x] `ApplicationEntity`, `OriginalApplicationEntity` 추가
- [x] 면접 가능 시간 이진수 형식으로 변환하는 기능 구현
- [x] OriginalApplicationEntity(지원서 원본)->ApplicationEntity 1차 변환 기능 구현

### 🧩 Related Issue
<!-- 이 PR이 승인되면 닫을 Issue 번호를 작성해주세요. -->
close #83

