### PR TITLE
[지원자] Application->Applicant 형식으로 변환하여 저장하는 기능 구현

### DIFF
--- a/src/main/java/com/picksa/picksaserver/application/controller/ApplicationController.java
+++ b/src/main/java/com/picksa/picksaserver/application/controller/ApplicationController.java
@@ -22,4 +22,10 @@ public class ApplicationController {
         return ResponseEntity.ok().build();
     }
 
+    @PostMapping("/applicant")
+    public ResponseEntity<Void> convertApplicationToApplicant() {
+        applicationConvertService.convertApplicationToApplicant();
+        return ResponseEntity.ok().build();
+    }
+
 }

--- a/src/main/java/com/picksa/picksaserver/application/dto/response/ApplicationDetailResponse.java
+++ b/src/main/java/com/picksa/picksaserver/application/dto/response/ApplicationDetailResponse.java
@@ -1,0 +1,71 @@
+package com.picksa.picksaserver.application.dto.response;
+
+import com.picksa.picksaserver.applicant.domain.ApplicantEntity;
+import com.picksa.picksaserver.application.domain.ApplicationEntity;
+import com.picksa.picksaserver.global.domain.Part;
+import lombok.Builder;
+
+@Builder
+public record ApplicationDetailResponse(
+        String name,
+        String studentId,
+        String email,
+        String gender,
+        String major,
+        String multiMajor,
+        String phone,
+        String semester,
+        String portfolio,
+        Part part,
+        int generation,
+        String commonAnswer1,
+        String commonAnswer2,
+        String commonAnswer3,
+        String commonAnswer4,
+        String commonAnswer5,
+        String partAnswer1,
+        String partAnswer2,
+        String partAnswer3,
+        String interviewAvailableTimes
+) {
+    public static ApplicationDetailResponse from(ApplicationEntity application) {
+        return ApplicationDetailResponse.builder()
+                .name(application.getPersonalData().getName())
+                .studentId(application.getPersonalData().getStudentId())
+                .email(application.getPersonalData().getEmail())
+                .gender(application.getPersonalData().getGender())
+                .major(application.getPersonalData().getMajor())
+                .multiMajor(application.getPersonalData().getMultiMajor())
+                .phone(application.getPersonalData().getPhone())
+                .semester(application.getPersonalData().getSemester())
+                .part(application.getPart())
+                .generation(application.getGeneration())
+                .commonAnswer1(application.getCommonAnswers().getCommonAnswer1())
+                .commonAnswer2(application.getCommonAnswers().getCommonAnswer2())
+                .commonAnswer3(application.getCommonAnswers().getCommonAnswer3())
+                .commonAnswer4(application.getCommonAnswers().getCommonAnswer4())
+                .commonAnswer5(application.getCommonAnswers().getCommonAnswer5())
+                .partAnswer1(application.getPartAnswers().getPartAnswer1())
+                .partAnswer2(application.getPartAnswers().getPartAnswer2())
+                .partAnswer3(application.getPartAnswers().getPartAnswer3())
+                .interviewAvailableTimes(application.getInterviewAvailableTimes())
+                .build();
+    }
+
+    public ApplicantEntity toEntity() {
+        return ApplicantEntity.builder()
+                .name(name)
+                .studentId(studentId)
+                .semester(semester)
+                .gender(gender)
+                .phone(phone)
+                .email(email)
+                .major(major)
+                .multiMajor(multiMajor)
+                .part(part)
+                .generation(generation)
+                .interviewAvailableTimes(interviewAvailableTimes)
+                .build();
+    }
+
+}

--- a/src/main/java/com/picksa/picksaserver/application/dto/response/ApplicationSyncResponse.java
+++ b/src/main/java/com/picksa/picksaserver/application/dto/response/ApplicationSyncResponse.java
@@ -1,0 +1,15 @@
+package com.picksa.picksaserver.application.dto.response;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record ApplicationSyncResponse(
+        LocalDateTime until,
+        List<ApplicationDetailResponse> applications
+) {
+
+    public static ApplicationSyncResponse of(LocalDateTime until, List<ApplicationDetailResponse> responses) {
+        return new ApplicationSyncResponse(until, responses);
+    }
+
+}

--- a/src/main/java/com/picksa/picksaserver/application/repository/ApplicationQueryRepository.java
+++ b/src/main/java/com/picksa/picksaserver/application/repository/ApplicationQueryRepository.java
@@ -1,0 +1,14 @@
+package com.picksa.picksaserver.application.repository;
+
+import com.picksa.picksaserver.application.dto.response.ApplicationDetailResponse;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public interface ApplicationQueryRepository {
+
+    List<ApplicationDetailResponse> getApplicationCreatedBetween(LocalDateTime after, LocalDateTime until);
+
+    List<ApplicationDetailResponse> getApplicationsUntil(LocalDateTime until);
+
+}

--- a/src/main/java/com/picksa/picksaserver/application/repository/ApplicationQueryRepositoryImpl.java
+++ b/src/main/java/com/picksa/picksaserver/application/repository/ApplicationQueryRepositoryImpl.java
@@ -1,0 +1,97 @@
+package com.picksa.picksaserver.application.repository;
+
+import com.picksa.picksaserver.application.dto.response.ApplicationDetailResponse;
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static com.picksa.picksaserver.application.domain.QApplicationEntity.applicationEntity;
+
+
+@Repository
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ApplicationQueryRepositoryImpl implements ApplicationQueryRepository {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public List<ApplicationDetailResponse> getApplicationCreatedBetween(LocalDateTime after, LocalDateTime until) {
+        return jpaQueryFactory.select(Projections.constructor(
+                        ApplicationDetailResponse.class,
+                        applicationEntity.personalData.name,
+                        applicationEntity.personalData.studentId,
+                        applicationEntity.personalData.email,
+                        applicationEntity.personalData.gender,
+                        applicationEntity.personalData.major,
+                        applicationEntity.personalData.multiMajor,
+                        applicationEntity.personalData.phone,
+                        applicationEntity.personalData.semester,
+                        applicationEntity.partAnswers.portfolio,
+                        applicationEntity.part,
+                        applicationEntity.generation,
+                        applicationEntity.commonAnswers.commonAnswer1,
+                        applicationEntity.commonAnswers.commonAnswer2,
+                        applicationEntity.commonAnswers.commonAnswer3,
+                        applicationEntity.commonAnswers.commonAnswer4,
+                        applicationEntity.commonAnswers.commonAnswer5,
+                        applicationEntity.partAnswers.partAnswer1,
+                        applicationEntity.partAnswers.partAnswer2,
+                        applicationEntity.partAnswers.partAnswer3,
+                        applicationEntity.interviewAvailableTimes
+                ))
+                .from(applicationEntity)
+                .where(
+                        applicationEntity.createdAt.after(after)
+                                .orAllOf(applicationEntity.createdAt.before(until),
+                                        applicationEntity.createdAt.eq(until)
+                                )
+                )
+                .orderBy(
+                        applicationEntity.createdAt.desc()
+                )
+                .fetch();
+    }
+
+    @Override
+    public List<ApplicationDetailResponse> getApplicationsUntil(LocalDateTime until) {
+        return jpaQueryFactory.select(Projections.constructor(
+                        ApplicationDetailResponse.class,
+                        applicationEntity.personalData.name,
+                        applicationEntity.personalData.studentId,
+                        applicationEntity.personalData.email,
+                        applicationEntity.personalData.gender,
+                        applicationEntity.personalData.major,
+                        applicationEntity.personalData.multiMajor,
+                        applicationEntity.personalData.phone,
+                        applicationEntity.personalData.semester,
+                        applicationEntity.partAnswers.portfolio,
+                        applicationEntity.part,
+                        applicationEntity.generation,
+                        applicationEntity.commonAnswers.commonAnswer1,
+                        applicationEntity.commonAnswers.commonAnswer2,
+                        applicationEntity.commonAnswers.commonAnswer3,
+                        applicationEntity.commonAnswers.commonAnswer4,
+                        applicationEntity.commonAnswers.commonAnswer5,
+                        applicationEntity.partAnswers.partAnswer1,
+                        applicationEntity.partAnswers.partAnswer2,
+                        applicationEntity.partAnswers.partAnswer3,
+                        applicationEntity.interviewAvailableTimes
+                ))
+                .from(applicationEntity)
+                .where(
+                        applicationEntity.createdAt.before(until)
+                                .or(applicationEntity.createdAt.eq(until))
+                )
+                .orderBy(
+                        applicationEntity.createdAt.desc()
+                )
+                .fetch();
+    }
+
+}

--- a/src/main/java/com/picksa/picksaserver/application/repository/ApplicationRepository.java
+++ b/src/main/java/com/picksa/picksaserver/application/repository/ApplicationRepository.java
@@ -1,0 +1,10 @@
+package com.picksa.picksaserver.application.repository;
+
+import com.picksa.picksaserver.application.domain.ApplicationEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ApplicationRepository extends JpaRepository<ApplicationEntity, Long>, ApplicationQueryRepository {
+
+    ApplicationEntity findTopByOrderByOriginalIdDesc();
+
+}

--- a/src/main/java/com/picksa/picksaserver/application/service/ApplicationConvertService.java
+++ b/src/main/java/com/picksa/picksaserver/application/service/ApplicationConvertService.java
@@ -1,0 +1,138 @@
+package com.picksa.picksaserver.application.service;
+
+import com.picksa.picksaserver.applicant.domain.AnswerEntity;
+import com.picksa.picksaserver.applicant.domain.ApplicantEntity;
+import com.picksa.picksaserver.applicant.repository.AnswerRepository;
+import com.picksa.picksaserver.applicant.repository.ApplicantRepository;
+import com.picksa.picksaserver.application.dto.response.ApplicationDetailResponse;
+import com.picksa.picksaserver.application.dto.response.ApplicationSyncResponse;
+import com.picksa.picksaserver.global.domain.Generation;
+import com.picksa.picksaserver.global.domain.Part;
+import com.picksa.picksaserver.question.QuestionEntity;
+import com.picksa.picksaserver.question.repository.QuestionRepository;
+import com.picksa.picksaserver.sync.domain.SyncRequestLog;
+import com.picksa.picksaserver.sync.repository.SyncLogRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ApplicationConvertService {
+
+    private final ApplicationService applicationService;
+    private final SyncLogRepository syncLogRepository;
+    private final QuestionRepository questionRepository;
+    private final ApplicantRepository applicantRepository;
+    private final AnswerRepository answerRepository;
+
+    // TODO: 2024-02-12 코드 가독성 개선
+    @Transactional
+    public void convertApplicationToApplicant() {
+        SyncRequestLog lastRequestLog = syncLogRepository.getFirstByOrderByCreatedAtDesc();
+        int generation = Generation.getGenerationOfThisYear();
+        List<QuestionEntity> questionEntities = questionRepository.findDeterminedQuestionsByGeneration(generation);
+        System.out.println("questionEntities.size() = " + questionEntities.size());
+        if (questionEntities.isEmpty()) {
+            throw new IllegalArgumentException("이번 기수의 질문이 존재하지 않습니다.");
+        }
+
+        // 올해의 질문 Map 구조로 변환
+        Map<Integer, Map<Part, QuestionEntity>> questions = new HashMap<>();
+        for (QuestionEntity question : questionEntities) {
+
+            if (!questions.containsKey(question.getSequence())) {
+                questions.put(question.getSequence(), new HashMap<Part, QuestionEntity>());
+            }
+
+            questions.get(question.getSequence()).put(question.getTag().getPart(), question);
+        }
+
+        for (Map.Entry<Integer, Map<Part, QuestionEntity>> sequence : questions.entrySet()) {
+            System.out.println(sequence.getKey() + " : " + sequence.getValue());
+        }
+
+
+        ApplicationSyncResponse response;
+        if (lastRequestLog == null) {
+            response = applicationService.getAllApplications();
+        } else {
+            response = applicationService.getApplicationsAfter(lastRequestLog.getProcessedAt());
+        }
+        System.out.println("response = " + response.applications().size());
+        SyncRequestLog newLog = SyncRequestLog.builder().processedAt(response.until()).build();
+        syncLogRepository.save(newLog);
+
+        // Application -> Applicant 변환
+        List<ApplicantEntity> applicants = new ArrayList<>();
+        List<AnswerEntity> answers = new ArrayList<>();
+        for (ApplicationDetailResponse application : response.applications()) {
+            ApplicantEntity applicant = application.toEntity();
+            applicants.add(applicant);
+
+            // 질문 답변 리스트로 변환
+            List<String> applicationAnswers = collectAnswersInList(application);
+            System.out.println("applicationAnswers.size() = " + applicationAnswers.size());
+            int index = 0;
+            Part applicationPart = application.part();
+            for (String applicationAnswer : applicationAnswers) {
+                if (applicationAnswer == null) {
+                    index++;
+                    continue;
+                }
+
+                if (questions.get(index+1).containsKey(Part.ALL)) {
+                    QuestionEntity question = questions.get(index + 1).get(Part.ALL);
+                    String answerContent = applicationAnswers.get(index);
+                    answers.add(createAnswerEntity(question, answerContent, applicant));
+                } else if (questions.get(index + 1).containsKey(application.part())) {
+                    QuestionEntity question = questions.get(index + 1).get(applicationPart);
+                    String answerContent = applicationAnswers.get(index);
+                    answers.add(createAnswerEntity(question, answerContent, applicant));
+                } else {
+                    index++;
+                    continue;
+                }
+
+                index++;
+            }
+
+        }
+
+        // 저장
+        applicantRepository.saveAll(applicants);
+        answerRepository.saveAll(answers);
+
+    }
+
+    // TODO: 2024-01-21 응집도 개선 (메서드 분리)
+    private List<String> collectAnswersInList(ApplicationDetailResponse application) {
+        List<String> applicationAnswers = new ArrayList<>();
+        applicationAnswers.add(application.commonAnswer1());
+        applicationAnswers.add(application.commonAnswer2());
+        applicationAnswers.add(application.commonAnswer3());
+        applicationAnswers.add(application.commonAnswer4());
+        applicationAnswers.add(application.commonAnswer5());
+        applicationAnswers.add(application.partAnswer1());
+        applicationAnswers.add(application.partAnswer2());
+        applicationAnswers.add(application.partAnswer3());
+
+        return applicationAnswers;
+    }
+
+    private AnswerEntity createAnswerEntity(QuestionEntity question, String answerContent, ApplicantEntity applicant) {
+        return AnswerEntity.builder()
+                .question(question)
+                .content(answerContent)
+                .applicant(applicant)
+                .build();
+    }
+
+}

--- a/src/main/java/com/picksa/picksaserver/application/service/ApplicationService.java
+++ b/src/main/java/com/picksa/picksaserver/application/service/ApplicationService.java
@@ -1,0 +1,33 @@
+package com.picksa.picksaserver.application.service;
+
+import com.picksa.picksaserver.application.dto.response.ApplicationDetailResponse;
+import com.picksa.picksaserver.application.dto.response.ApplicationSyncResponse;
+import com.picksa.picksaserver.application.repository.ApplicationRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ApplicationService {
+
+    private final ApplicationRepository applicationRepository;
+
+    public ApplicationSyncResponse getApplicationsAfter(LocalDateTime after) {
+        LocalDateTime until = LocalDateTime.now();
+        List<ApplicationDetailResponse> applicationDetailResponses = applicationRepository.getApplicationCreatedBetween(after, until);
+
+        return ApplicationSyncResponse.of(until, applicationDetailResponses);
+    }
+
+    public ApplicationSyncResponse getAllApplications() {
+        LocalDateTime until = LocalDateTime.now();
+        List<ApplicationDetailResponse> applicationDetailResponses = applicationRepository.getApplicationsUntil(until);
+        return ApplicationSyncResponse.of(until, applicationDetailResponses);
+    }
+
+}

--- a/src/main/java/com/picksa/picksaserver/auth/oAuth/service/OAuthService.java
+++ b/src/main/java/com/picksa/picksaserver/auth/oAuth/service/OAuthService.java
@@ -1,8 +1,8 @@
 package com.picksa.picksaserver.auth.oAuth.service;
 
+import com.picksa.picksaserver.auth.exception.AuthenticationUserNotExistException;
 import com.picksa.picksaserver.auth.oAuth.dto.OAuthUserInfoResponse;
 import com.picksa.picksaserver.auth.oAuth.dto.SignInResponse;
-import com.picksa.picksaserver.auth.exception.AuthenticationUserNotExistException;
 import com.picksa.picksaserver.global.auth.JwtProvider;
 import com.picksa.picksaserver.user.UserEntity;
 import com.picksa.picksaserver.user.repository.UserRepository;

--- a/src/main/java/com/picksa/picksaserver/evaluation/service/EvaluationService.java
+++ b/src/main/java/com/picksa/picksaserver/evaluation/service/EvaluationService.java
@@ -14,9 +14,6 @@ import com.picksa.picksaserver.global.domain.Generation;
 import com.picksa.picksaserver.user.Position;
 import com.picksa.picksaserver.user.UserEntity;
 import com.picksa.picksaserver.user.repository.UserRepository;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.core.Authentication;
@@ -26,11 +23,12 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Objects;
+import java.util.stream.Collectors;
 
 import static com.picksa.picksaserver.evaluation.exception.EvaluationExceptionMessage.ALREADY_EVALUATED;
+import static com.picksa.picksaserver.evaluation.exception.EvaluationExceptionMessage.UPDATE_NOT_PERMITTED;
 import static com.picksa.picksaserver.evaluation.exception.EvaluationExceptionMessage.USER_NOT_PART_LEADER;
 import static com.picksa.picksaserver.evaluation.exception.EvaluationExceptionMessage.USER_PART_MISMATCHED;
-import static com.picksa.picksaserver.evaluation.exception.EvaluationExceptionMessage.UPDATE_NOT_PERMITTED;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/com/picksa/picksaserver/global/response/DefaultErrorResponse.java
+++ b/src/main/java/com/picksa/picksaserver/global/response/DefaultErrorResponse.java
@@ -1,6 +1,5 @@
 package com.picksa.picksaserver.global.response;
 
-import com.picksa.picksaserver.global.exception.ErrorCode;
 import lombok.Getter;
 
 @Getter

--- a/src/main/java/com/picksa/picksaserver/question/repository/QuestionQueryRepository.java
+++ b/src/main/java/com/picksa/picksaserver/question/repository/QuestionQueryRepository.java
@@ -1,6 +1,7 @@
 package com.picksa.picksaserver.question.repository;
 
 import com.picksa.picksaserver.global.domain.Part;
+import com.picksa.picksaserver.question.QuestionEntity;
 import com.picksa.picksaserver.question.QuestionOrderCondition;
 import com.picksa.picksaserver.question.dto.response.QuestionResponse;
 
@@ -11,4 +12,7 @@ public interface QuestionQueryRepository {
     List<QuestionResponse> findAllQuestionsByPart(Part part, QuestionOrderCondition condition, int generation);
 
     List<QuestionResponse> findDeterminedQuestionsByPart(Part part, int generation);
+
+    List<QuestionEntity> findDeterminedQuestionsByGeneration(int generation);
+
 }

--- a/src/main/java/com/picksa/picksaserver/question/repository/QuestionRepository.java
+++ b/src/main/java/com/picksa/picksaserver/question/repository/QuestionRepository.java
@@ -4,4 +4,5 @@ import com.picksa.picksaserver.question.QuestionEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface QuestionRepository extends JpaRepository<QuestionEntity, Long>, QuestionQueryRepository {
+
 }

--- a/src/main/java/com/picksa/picksaserver/question/repository/QuestionRepositoryImpl.java
+++ b/src/main/java/com/picksa/picksaserver/question/repository/QuestionRepositoryImpl.java
@@ -1,6 +1,7 @@
 package com.picksa.picksaserver.question.repository;
 
 import com.picksa.picksaserver.global.domain.Part;
+import com.picksa.picksaserver.question.QuestionEntity;
 import com.picksa.picksaserver.question.QuestionOrderCondition;
 import com.picksa.picksaserver.question.dto.response.QuestionResponse;
 import com.querydsl.core.types.Projections;
@@ -78,6 +79,19 @@ public class QuestionRepositoryImpl implements QuestionQueryRepository {
                             questionEntity.tag.part.asc(),
                             questionEntity.sequence.asc())
                     .fetch();
+    }
+
+    @Override
+    public List<QuestionEntity> findDeterminedQuestionsByGeneration(int generation) {
+        return jpaQueryFactory.selectFrom(questionEntity)
+                .where(
+                        questionEntity.tag.generation.eq(generation),
+                        questionEntity.isDetermined.eq(true),
+                        questionEntity.deletedAt.isNull()
+                )
+                .orderBy(
+                        questionEntity.sequence.asc())
+                .fetch();
     }
 
 }

--- a/src/main/java/com/picksa/picksaserver/sync/domain/SyncRequestLog.java
+++ b/src/main/java/com/picksa/picksaserver/sync/domain/SyncRequestLog.java
@@ -1,0 +1,35 @@
+package com.picksa.picksaserver.sync.domain;
+
+import com.picksa.picksaserver.global.domain.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Table(name = "sync_request_logs")
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class SyncRequestLog extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "processed_at", nullable = false, columnDefinition = "TIMESTAMP(6)")
+    private LocalDateTime processedAt;
+
+    @Builder
+    public SyncRequestLog(LocalDateTime processedAt) {
+        this.processedAt = processedAt;
+    }
+
+}

--- a/src/main/java/com/picksa/picksaserver/sync/repository/SyncLogRepository.java
+++ b/src/main/java/com/picksa/picksaserver/sync/repository/SyncLogRepository.java
@@ -1,0 +1,10 @@
+package com.picksa.picksaserver.sync.repository;
+
+import com.picksa.picksaserver.sync.domain.SyncRequestLog;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SyncLogRepository extends JpaRepository<SyncRequestLog, Long> {
+
+    SyncRequestLog getFirstByOrderByCreatedAtDesc();
+
+}


### PR DESCRIPTION
## 📃 Describe
<!-- 무엇을 위한 PR인지 간략하게 적어주세요-->
`Application `데이터를 `Applicant `형식으로 변환하여 저장하는 기능을 구현합니다.
정규화를 위해 Applicant는 지원서 응답을 Answer 테이블에 분리하여 저장하고 있으므로 형식의 변환이 필요합니다.

### 🦁 Changes
<!-- 변경 사항을 적어주세요 -->
- [x] `Application `데이터를 `Applicant `형식으로 변환하여 저장하는 기능을 구현

### 🧩 Related Issue
<!-- 이 PR이 승인되면 닫을 Issue 번호를 작성해주세요. -->
close #86

