### PR TITLE
[지원자] Application->Applicant 변환 시 portfolio 누락되는 문제 해결

### DIFF
--- a/src/main/java/com/picksa/picksaserver/application/dto/response/ApplicationDetailResponse.java
+++ b/src/main/java/com/picksa/picksaserver/application/dto/response/ApplicationDetailResponse.java
@@ -64,6 +64,7 @@ public record ApplicationDetailResponse(
                 .multiMajor(multiMajor)
                 .part(part)
                 .generation(generation)
+                .portfolio(portfolio)
                 .interviewAvailableTimes(interviewAvailableTimes)
                 .build();
     }


### PR DESCRIPTION
## 📃 Describe
<!-- 무엇을 위한 PR인지 간략하게 적어주세요-->
`Application`->`Applicant `변환 시 `portfolio `데이터가 누락되는 문제가 있었습니다.
`ApplicationDetailResponse`의 `toEntity()`메서드에서 `portfolio`데이터 값을 넣는 과정이 누락됨을 확인하여 수정하였습니다.

### 🦁 Changes
<!-- 변경 사항을 적어주세요 -->
- [ ] `ApplicationDetailResponse`의 `toEntity()`메서드에서 `portfolio` 반영

### 🧩 Related Issue
<!-- 이 PR이 승인되면 닫을 Issue 번호를 작성해주세요. -->
close #88 

